### PR TITLE
Mixin override bug

### DIFF
--- a/src/dotless.Core/Parser/Infrastructure/Env.cs
+++ b/src/dotless.Core/Parser/Infrastructure/Env.cs
@@ -42,10 +42,12 @@
 
         public List<Closure> FindRulesets(Selector selector)
         {
-            return Frames.Select(frame => frame.Find(this, selector, null)).FirstOrDefault(r => r.Count != 0);
+        	return Frames.Select(frame => frame.Find(this, selector, null))
+        		.Where(f => !f.Any(c => Frames.Contains(c.Ruleset)))
+				.FirstOrDefault(r => r.Count != 0);
         }
 
-        public virtual Function GetFunction(string name)
+    	public virtual Function GetFunction(string name)
         {
             if (_functionTypes == null)
             {

--- a/src/dotless.Test/Unit/Engine/MixinOverrideBug.cs
+++ b/src/dotless.Test/Unit/Engine/MixinOverrideBug.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace dotless.Test.Unit.Engine
+{
+	using NUnit.Framework;
+
+	public class MixinOverrideBug : SpecFixtureBase
+	{
+		[Test]
+		public void Mixin_override_stack_overflow()
+		{
+
+			var input = @"
+.button
+{
+    background-color: black;
+    color: white;
+}
+
+.red-skin
+{
+    .button
+    {
+        .button;
+
+        background-color: red;
+    }
+}";
+
+			var expected = @"
+.button {
+  background-color: black;
+  color: white;
+}
+.red-skin .button {
+  background-color: black;
+  color: white;
+  background-color: red;
+}
+";
+
+			AssertLess(input, expected);
+		}
+	}
+}

--- a/src/dotless.Test/dotless.Test.csproj
+++ b/src/dotless.Test/dotless.Test.csproj
@@ -94,6 +94,7 @@
     <Compile Include="TestStylizer.cs" />
     <Compile Include="Unit\Engine\CacheDecoratorFixture.cs" />
     <Compile Include="Unit\Engine\CommentBug.cs" />
+    <Compile Include="Unit\Engine\MixinOverrideBug.cs" />
     <Compile Include="Unit\Engine\NullVariableValueBug.cs" />
     <Compile Include="Unit\Engine\ParameterDecoratorFixture.cs" />
     <Compile Include="Unit\Engine\PathAggregatorBug.cs" />


### PR DESCRIPTION
When we encounter a rule call and we look for the rule set to evaluate, we should not treat rule sets currently on the stack as candidates.

This should fix dotless/dotless#13. 

The fix is in the mixin-override-bug branch. I seem to have fouled up the whitespaces, so please pay close attention to Env.cs, line 46, when considering the pull.
