### PR TITLE
A better version of the comment fixed

### DIFF
--- a/src/dotless.Core/Parser/Infrastructure/DefaultNodeProvider.cs
+++ b/src/dotless.Core/Parser/Infrastructure/DefaultNodeProvider.cs
@@ -17,7 +17,7 @@ namespace dotless.Core.Parser.Infrastructure
             return new Combinator(value) { Index = index };
         }
 
-        public Selector Selector(NodeList<Element> elements, int index)
+        public Selector Selector(NodeList<Node> elements, int index)
         {
             return new Selector(elements) { Index = index };
         }

--- a/src/dotless.Core/Parser/Infrastructure/INodeProvider.cs
+++ b/src/dotless.Core/Parser/Infrastructure/INodeProvider.cs
@@ -9,7 +9,7 @@ namespace dotless.Core.Parser.Infrastructure
     {
         Element Element(Combinator combinator, string value, int index);
         Combinator Combinator(string value, int index);
-        Selector Selector(NodeList<Element> elements, int index);
+        Selector Selector(NodeList<Node> elements, int index);
         Rule Rule(string name, Node value, int index);
         Ruleset Ruleset(NodeList<Selector> selectors, List<Node> rules, int index);
 

--- a/src/dotless.Core/Parser/Parsers.cs
+++ b/src/dotless.Core/Parser/Parsers.cs
@@ -70,8 +70,8 @@ namespace dotless.Core.Parser
             Node node;
             var root = new List<Node>();
 
-            while (node = MixinDefinition(parser) || Rule(parser) || Ruleset(parser) ||
-                          MixinCall(parser) || Comment(parser) || Directive(parser))
+            while (node = MixinDefinition(parser) || Rule(parser) || Comment(parser) || Ruleset(parser) ||
+                          MixinCall(parser) || Directive(parser))
             {
                 root.Add(node);
             }
@@ -92,11 +92,13 @@ namespace dotless.Core.Parser
             if(comment)
                 return NodeProvider.Comment(comment.Value, true, index);
 
-            comment = parser.Tokenizer.Match(@"/\*(?:[^*]|\*+[^\/*])*\*+/\n?");
+            comment = parser.Tokenizer.Match(@"/\*(.|[\r\n])*?\*/");
             if (comment) {
-				if (comment.Value == @"/*\*/") {
-					throw new ParsingException("The IE6 comment hack is not supported", parser.Tokenizer.Location.Index);
-				}
+				
+				//Once CSS Hacks are supported, implement this exception
+				//if (comment.Value.EndsWith(@"\*/")) {
+				//	throw new ParsingException("The IE6 comment hack is not supported", parser.Tokenizer.Location.Index);
+				//}
                 return NodeProvider.Comment(comment.Value, index);
 			}
 
@@ -509,11 +511,11 @@ namespace dotless.Core.Parser
         // they are made out of a `Combinator` (see combinator rule),
         // and an element name, such as a tag a class, or `*`.
         //
-        public Element Element(Parser parser, Combinator c)
+        public Element Element(Parser parser)
         {
             var index = parser.Tokenizer.Location.Index;
 
-            c = (Combinator)(c || Combinator(parser));
+            Combinator c = Combinator(parser);
             var e = parser.Tokenizer.Match(@"[.#:]?[a-zA-Z0-9_-]+") || parser.Tokenizer.Match('*') || Attribute(parser) ||
                     parser.Tokenizer.Match(@"\([^)@]+\)");
 
@@ -553,27 +555,32 @@ namespace dotless.Core.Parser
         //
         public Selector Selector(Parser parser)
         {
-            Element e;
-			Combinator c = null;
-            var elements = new NodeList<Element>();
-
+            Node e;
+			int realElements = 0;
+			
+            var elements = new NodeList<Node>();
             var index = parser.Tokenizer.Location.Index;
 			
+			// absorb comments at the start of selectors
+			while(e = Comment(parser)) elements.Add(e);
+			
             while (true) {
-				// absorb comments at the end of selectors and elements. Replace them with whitespace
-				while(Comment(parser)) c = NodeProvider.Combinator(" ", index);
-				
-				e = Element(parser, c);
+				e = Element(parser); // combinator handles comments in the middle of selectors
 				if  (!e) {
 					break;
 				}
+				realElements++;
                 elements.Add(e);
-				c = null;
 			}
 			
-            if (elements.Count > 0)
+			// absorb comments at the end of selectors
+			while(e = Comment(parser)) elements.Add(e);
+			
+            if (realElements > 0)
                 return NodeProvider.Selector(elements, index);
-
+			
+			//We have lost comments we have absorbed here.
+			//But comments should be absorbed before selectors...
             return null;
         }
 
@@ -638,12 +645,12 @@ namespace dotless.Core.Parser
 
             var memo = parser.Tokenizer.Location;
 
-            if (parser.Tokenizer.Peek(@"([a-z.#: _-]+)[\s\n]*\{"))
+            if (parser.Tokenizer.Peek(@"([a-z.#: _-]+)[\s\n]*\{")) //simple case with no comments
             {
                 var match = parser.Tokenizer.Match(@"[a-z.#: _-]+");
                 selectors =
                     new NodeList<Selector>(
-                        NodeProvider.Selector(new NodeList<Element>(NodeProvider.Element(null, match.Value, memo.Index)), memo.Index));
+                        NodeProvider.Selector(new NodeList<Node>(NodeProvider.Element(null, match.Value, memo.Index)), memo.Index));
             }
             else
             {
@@ -654,7 +661,6 @@ namespace dotless.Core.Parser
                     if (!parser.Tokenizer.Match(','))
                         break;
                 }
-                if (s) Comment(parser);
             }
 
             List<Node> rules;

--- a/src/dotless.Core/Parser/Tokenizer.cs
+++ b/src/dotless.Core/Parser/Tokenizer.cs
@@ -46,22 +46,21 @@ namespace dotless.Core.Parser
                 var chunkParts = new List<StringBuilder> { new StringBuilder() };
                 var chunkPart = chunkParts.Last();
                 var skip = new Regex(@"\G[^\""'{}/\\]+");
-                var comment = new Regex(@"\G(\/\/[^\n]*|(\/\*(?:[^*\n]|\*+[^\/\n]|\*?(\n))*?\*+\/))");
+                var comment = new Regex(@"\G(//[^\n]*|(/\*(.|[\r\n])*?\*/))");
                 var level = 0;
                 var lastBlock = 0;
                 var lastQuote = 0;
                 char? inString = null;
-
-                for (int i = 0; i < _inputLength; i++)
+				
+				int i = 0;
+                while(i < _inputLength)
                 {
                     var match = skip.Match(_input, i);
                     if(match.Success)
                     {
                         chunkPart.Append(match.Value);
                         i += match.Length;
-
-                        if (i == _inputLength)
-                            break;
+						continue;
                     }
 
 
@@ -75,9 +74,7 @@ namespace dotless.Core.Parser
                             {
                                 i += match.Length;
                                 chunkPart.Append(match.Value);
-
-                                if (i == _inputLength)
-                                    break;
+								continue;
                             }
                         }
                     }
@@ -101,7 +98,7 @@ namespace dotless.Core.Parser
                     else if (inString != null && c == '\\' && i < _inputLength - 1)
                     {
                         chunkPart.Append(_input, i, 2);
-                        i++;
+                        i+=2;
                         continue;
                     }
                     else if (inString == null && c == '{')
@@ -119,10 +116,12 @@ namespace dotless.Core.Parser
                         chunkPart.Append(c);
                         chunkPart = new StringBuilder();
                         chunkParts.Add(chunkPart);
+						i++;
                         continue;
                     }
 
                     chunkPart.Append(c);
+					i++;
                 }
 
                 if(inString != null)

--- a/src/dotless.Test/Specs/CommentsFixture.cs
+++ b/src/dotless.Test/Specs/CommentsFixture.cs
@@ -1,7 +1,8 @@
 namespace dotless.Test.Specs
 {
     using NUnit.Framework;
-
+	using dotless.Core.Exceptions;
+	
     public class CommentsFixture : SpecFixtureBase
     {
         [Test]
@@ -58,7 +59,7 @@ namespace dotless.Test.Specs
 
             AssertLess(input, expected);
         }
-
+		
         [Test]
         public void ColorInsideComments()
         {
@@ -118,7 +119,7 @@ namespace dotless.Test.Specs
 ";
 
             var expected = @"
-#comments {
+#comments/* boo */ {
   color: red;
 }
 ";
@@ -143,7 +144,6 @@ namespace dotless.Test.Specs
 #comments {
   border: solid black;
   /**/
-
   color: red;
 }
 ";
@@ -169,7 +169,6 @@ namespace dotless.Test.Specs
   border: solid black;
   color: red;
   /* A C-style comment */
-
   padding: 0;
 }
 ";
@@ -259,7 +258,7 @@ namespace dotless.Test.Specs
 ";
 
             var expected = @"
-#comments {
+#comments/* boo */ {
   color: red;
 }
 ";
@@ -298,16 +297,14 @@ namespace dotless.Test.Specs
             AssertLessUnchanged(input);
         }
 
-        [Test, Ignore("Bug")]
+        [Test]
         public void BlockCommented3()
         {
             var input =
                 @"
-/* commented out
-  #more-comments {
-    quotes: ""/*"" ""*/"";
-  }
-*/
+#more-comments {
+  quotes: ""/*"" ""*/"";
+}
 ";
 
             AssertLessUnchanged(input);
@@ -330,6 +327,87 @@ namespace dotless.Test.Specs
 ";
 
             AssertLess(input, expected);
+        }
+		
+		[Test]
+		[ExpectedException(typeof(ParserException))]
+        public void CheckCommentsAreNotAcceptedAsASelector()
+        {
+			// Note: https://github.com/dotless/dotless/issues/31
+        	var input = @"/* COMMENT *//* COMMENT */, /* COMMENT */,/* COMMENT */ .clb /* COMMENT */ {background-image: url(pickture.asp);}";
+
+            AssertLessUnchanged(input);
+        }
+		
+		[Test]
+        public void CheckCommentsAreAcceptedBetweenSelectors()
+        {
+			// Note: https://github.com/dotless/dotless/issues/31
+        	var input = @"/* COMMENT */body/* COMMENT */,/* COMMENT */ .clb /* COMMENT */ {background-image: url(pickture.asp);}";
+
+			var expected = @"/* COMMENT */body/* COMMENT */, /* COMMENT */ .clb/* COMMENT */ {
+  background-image: url(pickture.asp);
+}";
+			
+            AssertLess(input, expected);
+        }
+		
+		[Test, Ignore("Bug to fix in the future - dotLess still doesn't allow comments everywhere")]
+        public void CheckCommentsAreAcceptedWhereWhitespaceIsAllowed()
+        {
+			// Note: https://github.com/dotless/dotless/issues/31
+        	var input = @"/* COMMENT */body/* COMMENT */, /* COMMENT */.cls/* COMMENT */ .cla,/* COMMENT */ .clb /* COMMENT */ {background-image: url(pickture.asp);}";
+
+			var expected = @"body, .cls .cla, .clb {
+  background-image: url(pickture.asp);
+}";
+			
+            AssertLess(input, expected);
+        }
+		
+		[Test, Ignore("Bug to fix in the future - dotLess still doesn't allow comments everywhere")]
+        public void CheckCommentsAreTakenToBeWhitespace1()
+        {
+        	var input = @".cls/* COMMENT */.cla {background-image: url(pickture.asp);}";
+
+			var expected = @".cls .cla {
+  background-image: url(pickture.asp);
+}";
+			
+            AssertLess(input, expected);
+        }
+		
+		[Test, Ignore("Bug to fix in the future - dotLess still doesn't allow comments everywhere")]
+        public void CheckCommentsAreTakenToBeWhitespace2()
+        {
+        	var input = @".cls/* COMMENT */ + /* COMMENT */.cla {background-image: url(pickture.asp);}";
+
+			var expected = @".cls + .cla {
+  background-image: url(pickture.asp);
+}";
+			
+            AssertLess(input, expected);
+        }
+		
+		[Test]
+        public void CommentCSSHackException1Accepted()
+        {
+        	var input = @"/*\*/.cls {background-image: url(picture.asp);} /**/";
+			
+			var expected = @"/*\*/.cls {
+  background-image: url(picture.asp);
+}
+/**/";
+
+            AssertLess(input, expected);
+        }
+		
+		[Test]
+        public void CommentCSSHackException2Accepted()
+        {
+        	var input = @"/*\*//*/ .cls {background-image: url(picture.asp);} /**/";
+
+            AssertLessUnchanged(input);
         }
     }
 }

--- a/src/dotless.Test/Specs/CssFixture.cs
+++ b/src/dotless.Test/Specs/CssFixture.cs
@@ -1,7 +1,6 @@
 namespace dotless.Test.Specs
 {
     using NUnit.Framework;
-	using dotless.Core.Exceptions;
 
     public class CssFixture : SpecFixtureBase
     {
@@ -289,57 +288,6 @@ form[data-disabled] {
 }";
 
             AssertLessUnchanged(input);
-        }
-		
-		[Test]
-        public void CheckCommentsAreAcceptedWhereWhitespaceIsAllowed()
-        {
-			// Note: https://github.com/dotless/dotless/issues/31
-        	var input = @"/* COMMENT */body/* COMMENT */, /* COMMENT */.cls/* COMMENT */ .cla,/* COMMENT */ .clb /* COMMENT */ {background-image: url(pickture.asp);}";
-
-			var expected = @"body, .cls .cla, .clb {
-  background-image: url(pickture.asp);
-}";
-			
-            AssertLess(input, expected);
-        }
-		
-		[Test]
-        public void CheckCommentsAreTakenToBeWhitespace()
-        {
-        	var input = @".cls/* COMMENT */.cla {background-image: url(pickture.asp);}";
-
-			var expected = @".cls .cla {
-  background-image: url(pickture.asp);
-}";
-			
-            AssertLess(input, expected);
-        }
-		
-		[Test]
-		[ExpectedException(typeof(ParserException), ExpectedMessage = @"The IE6 comment hack is not supported", MatchType=MessageMatch.Contains)]
-        public void CommentCSSHackException1()
-        {
-        	var input = @"/*\*/ .cls {background-image: url(picture.asp);} /**/";
-
-			var expected = @"/*\*/ .cls {
-  background-image: url(pickture.asp);
-} /**/";
-			
-            AssertLess(input, expected);
-        }
-		
-		[Test]
-		[ExpectedException(typeof(ParserException), ExpectedMessage = @"The IE6 comment hack is not supported", MatchType=MessageMatch.Contains)]
-        public void CommentCSSHackException2()
-        {
-        	var input = @"/*\*//*/ .cls {background-image: url(picture.asp);} /**/";
-
-			var expected = @"/*\*//*/ .cls {
-  background-image: url(pickture.asp);
-} /**/";
-			
-            AssertLess(input, expected);
         }
     }
 }

--- a/src/dotless.Test/Unit/Engine/CommentBug.cs
+++ b/src/dotless.Test/Unit/Engine/CommentBug.cs
@@ -18,7 +18,7 @@ body
 }";
 
         	var expected =
-        		@"body {
+        		@"/* Block comment ********************/body {
   background-color: yellow;
   /* Another block comment */
 }";


### PR DESCRIPTION
I haven't yet got

.a /_comment_/ + .b /\* comment*/ {
}

to work, so I excluded that possibility.

I also simplified the regular expression for comments using non-greedy instead of something far more complicated. Also fixed a bug in the tokenizer.
