### PR TITLE
Improve parser exceptions ++

### DIFF
--- a/src/dotless.Core/Parser/Parser.cs
+++ b/src/dotless.Core/Parser/Parser.cs
@@ -93,7 +93,6 @@ namespace dotless.Core.Parser
 
         public Ruleset Parse(string input,  string fileName)
         {
-            Tokenizer.SetupInput(input);
             ParsingException parsingException = null;
             Ruleset root = null;
 

--- a/src/dotless.Core/Parser/Tokenizer.cs
+++ b/src/dotless.Core/Parser/Tokenizer.cs
@@ -39,94 +39,88 @@ namespace dotless.Core.Parser
             // delmited by '\n}' (see rationale above),
             // depending on the level of optimization.
 
-            if (Optimization == 0)
+            if(Optimization == 0)
                 _chunks.Add(_input);
             else
             {
                 var chunkParts = new List<StringBuilder> { new StringBuilder() };
                 var chunkPart = chunkParts.Last();
                 var skip = new Regex(@"\G[^\""'{}/\\]+");
+                // these two use the same regex as the parser. We could consider putting them somewhere global
                 var comment = new Regex(@"\G(//[^\n]*|(/\*(.|[\r\n])*?\*/))");
+                var quotedstring = new Regex(@"\G(""((?:[^""\\\r\n]|\\.)*)""|'((?:[^'\\\r\n]|\\.)*)')");
                 var level = 0;
                 var lastBlock = 0;
-                var lastQuote = 0;
-                char? inString = null;
-				
-				int i = 0;
+                
+                int i = 0;
                 while(i < _inputLength)
                 {
+                    
                     var match = skip.Match(_input, i);
                     if(match.Success)
                     {
                         chunkPart.Append(match.Value);
                         i += match.Length;
-						continue;
+                        continue;
                     }
-
-
-                    if(i < _inputLength - 1 && _input[i] == '/' && inString == null)
+                    
+                    var c = _input[i];
+                    
+                    if(i < _inputLength - 1 && c == '/')
                     {
                         var cc = _input[i + 1];
-                        if(cc == '/' || cc=='*')
+                        if(cc == '/' || cc == '*')
                         {
                             match = comment.Match(_input, i);
-                            if (match.Success)
+                            if(match.Success)
                             {
                                 i += match.Length;
                                 chunkPart.Append(match.Value);
-								continue;
+                                continue;
+                            } else
+                            {
+                                throw new ParsingException("Missing closing comment", i);
                             }
                         }
                     }
-
-                    var c = _input[i];
-
-                    if (c == '"' || c == '\'')
+                    
+                    if(c == '"' || c == '\'')
                     {
-                        if (inString == null)
+                        match = quotedstring.Match(_input, i);
+                        if(match.Success)
                         {
-                            inString = c;
-                            lastQuote = i;
+                            i += match.Length;
+                            chunkPart.Append(match.Value);
+                            continue;
+                        } else
+                        {
+                            throw new ParsingException(string.Format("Missing closing quote ({0})", c), i);
                         }
-                        else
-                            inString = inString == c ? null : inString;
                     }
-//                    else if (inString != null && c == '\n')
-//                    {
-//                        throw new ParsingException(string.Format("Missing closing quote ({0})", inString), lastQuote);
-//                    }
-                    else if (inString != null && c == '\\' && i < _inputLength - 1)
-                    {
-                        chunkPart.Append(_input, i, 2);
-                        i+=2;
-                        continue;
-                    }
-                    else if (inString == null && c == '{')
+                    
+                    // we are not in a quoted string or comment - process '{' level
+                    if(c == '{')
                     {
                         level++;
                         lastBlock = i;
-                    }
-                    else if (inString == null && c == '}')
+                    } else if(c == '}')
                     {
                         level--;
-
-                        if (level < 0)
+                        
+                        if(level < 0)
                             throw new ParsingException("Unexpected '}'", i);
-
+                        
                         chunkPart.Append(c);
                         chunkPart = new StringBuilder();
                         chunkParts.Add(chunkPart);
-						i++;
+                        i++;
                         continue;
                     }
-
+                    
                     chunkPart.Append(c);
-					i++;
+                    i++;
                 }
-
-                if(inString != null)
-                    throw new ParsingException(string.Format("Missing closing quote ({0})", inString), lastQuote);
-
+                
                 if(level > 0)
                     throw new ParsingException("Missing closing '}'", lastBlock);
 

--- a/src/dotless.Test/Specs/CssFixture.cs
+++ b/src/dotless.Test/Specs/CssFixture.cs
@@ -289,5 +289,17 @@ form[data-disabled] {
 
             AssertLessUnchanged(input);
         }
+		
+		[Test]
+		public void CheckUrlWithData() 
+		{
+
+			var input = @".help-icon {
+  width: 16px;
+  height: 16px;
+  background: url(""data:image/gif;base64,R0lGODlhDAAMAMQAAAAAAP////T4/ujx/ery/UKP7k6W71CX71KY71Sa8Gak8XGr8nWu83ev83qv83ux83yx832y85XA9aHH96rN+KvO+KzO+K3O+LnV+cTc+tDj+9Xm+////wAAAAAAAAAAACH5BAEAABwALAAAAAAMAAwAAAVKIMcRVoMgjUWI3BYVcOxs41tIGqbAEQkvgshkECv9XopAzBQrKASX2KmZyTRRzUYia2lqdkWCrbAwxHqtRxMGoYkIFcbhwKCsOCEAOw=="") center bottom no-repeat;
+}";
+			AssertLessUnchanged(input);
+		}
     }
 }

--- a/src/dotless.Test/Specs/StringsFixture.cs
+++ b/src/dotless.Test/Specs/StringsFixture.cs
@@ -42,6 +42,12 @@ namespace dotless.Test.Specs
         }
 
         [Test]
+        public void BracesInQuotesUneven()
+        {
+            AssertExpressionUnchanged(@"""{"" """"");
+        }
+
+        [Test]
         public void SemiColonInQuotes()
         {
             AssertExpressionUnchanged(@"';'");

--- a/src/dotless.Test/Unit/Engine/ParserExceptions.cs
+++ b/src/dotless.Test/Unit/Engine/ParserExceptions.cs
@@ -1,0 +1,249 @@
+namespace dotless.Test.Unit.Engine
+{
+    using NUnit.Framework;
+    using dotless.Core.Exceptions;
+
+    public class ParserExceptions : SpecFixtureBase
+    {
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"
+Missing closing quote ("") on line 3:", MatchType = MessageMatch.Contains)]
+        public void NewLineInStringNotSupported1()
+        {
+            // this was never supported in the parser but is now not supported in the tokenizer either
+            AssertExpressionUnchanged(@"""
+""");
+            AssertExpressionUnchanged(@"""\
+""");
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"
+Missing closing quote ("") on line 3:", MatchType = MessageMatch.Contains)]
+        public void NewLineInStringNotSupported2()
+        {
+            // this was never supported in the parser but is now not supported in the tokenizer either
+            AssertExpressionUnchanged(@"""\
+""");
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage=@"
+Missing closing quote ("") on line 1:", MatchType=MessageMatch.Contains)]
+        public void NoEndDoubleQuote()
+        {
+        	var input =
+        		@"
+.cla { background-image: ""my-image.jpg; }
+
+.clb { background-image: ""my-second-image.jpg""; }";
+			
+            AssertLessUnchanged(input);
+        }
+		
+      [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"
+Missing closing quote ("") on line 1", MatchType = MessageMatch.Contains)]
+        public void NoEndDoubleQuote2()
+        {
+        	var input =
+        		@"
+.cla { background-image: ""my-image.jpg; } 
+
+.clb { background-position: 12px 3px; }";
+			
+            AssertLessUnchanged(input);
+        }
+		
+      [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"
+Missing closing quote (') on line 1:", MatchType = MessageMatch.Contains)]
+        public void NoEndSingleQuote()
+        {
+        	var input =
+        		@"
+.cla { background-image: 'my-image.jpg; }
+
+.clb { background-image: 'my-second-image.jpg'; }";
+			
+            AssertLessUnchanged(input);
+        }
+		
+      [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"
+Missing closing quote (') on line 1:", MatchType = MessageMatch.Contains)]
+        public void NoEndSingleQuote2()
+        {
+        	var input =
+        		@"
+.cla { background-image: 'my-image.jpg; }
+
+.clb { background-position: 12px 3px; }";
+			
+            AssertLessUnchanged(input);
+        }
+		
+      [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"
+Missing closing quote (') on line 1:", MatchType = MessageMatch.Contains)]
+        public void NoEndSingleQuote3()
+        {
+        	var input =
+        		@"
+.cla { background-image: 'my-image.jpg; } /* comment
+
+.clb { background-position: 12px 3px; }*/";
+			
+            AssertLessUnchanged(input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"
+Missing closing quote (') on line 1:", MatchType = MessageMatch.Contains)]
+        public void NoEndSingleQuote4 ()
+        {
+            var input = @"
+.cla { background-image: 'my-image.jpg; }";
+            
+            AssertLessUnchanged (input);
+        }
+		
+      [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"
+Missing closing comment on line 1:", MatchType = MessageMatch.Contains)]
+        public void NoEndComment()
+        {
+        	var input =
+        		@".cla { background-image: 'my-image.jpg'; } /* My comment starts here but isn't closed
+
+.clb { background-image: 'my-second-image.jpg'; }";
+			
+            AssertLessUnchanged(input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        [Ignore("Would be nice to detect, but too difficult at the moment - probably easier to fix")]
+        public void CommentNotSupported1 ()
+        {
+            var input = @".cla/*comment*/.clb{ background-image: 'my-image.jpg'; }";
+
+            AssertLessUnchanged (input);
+        }
+
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        [Ignore("Would be nice to detect, but too difficult at the moment - probably easier to fix")]
+        public void CommentNotSupported3 ()
+        {
+            var input = @".cla .clb{ background-image/*comment*/: 'my-image.jpg'; }";
+
+            AssertLessUnchanged (input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        [Ignore("Would be nice to detect, but too difficult at the moment - probably easier to fix")]
+        public void CommentNotSupported4 ()
+        {
+            var input = @".cla .clb{ background-image:/*comment*/ 'my-image.jpg'; }";
+            
+            AssertLessUnchanged (input);
+        }
+
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        [Ignore("Would be nice to detect, but too difficult at the moment - probably easier to fix")]
+        public void CommentNotSupported5 ()
+        {
+            var input = @".cla .clb{ background-image: 'my-image.jpg'/*comment*/; }";
+
+            AssertLessUnchanged (input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        [Ignore("Would be nice to detect, but too difficult at the moment - probably easier to fix")]
+        public void CommentNotSupported6 ()
+        {
+            var input = @"@a/*comment*/ : 12 + 4;";
+            
+            AssertLessUnchanged (input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        [Ignore("Would be nice to detect, but too difficult at the moment - probably easier to fix")]
+        public void CommentNotSupported7 ()
+        {
+            var input = @"@a : /*comment*/12 + 4;";
+
+            AssertLessUnchanged (input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        [Ignore("Would be nice to detect, but too difficult at the moment - probably easier to fix")]
+        public void CommentNotSupported8 ()
+        {
+            var input = @"@a : 12 /*comment*/+ 4;";
+
+            AssertLessUnchanged (input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        [Ignore("Would be nice to detect, but too difficult at the moment - probably easier to fix")]
+        public void CommentNotSupported9 ()
+        {
+            var input = @"@a : 12 + /*comment*/4;";
+
+            AssertLessUnchanged (input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        [Ignore("Would be nice to detect, but too difficult at the moment - probably easier to fix")]
+        public void CommentNotSupported10 ()
+        {
+            var input = @"@a : 12 + 4/*comment*/;";
+
+            AssertLessUnchanged (input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        [Ignore("Would be nice to detect, but too difficult at the moment - probably easier to fix")]
+        public void CommentNotSupported11 ()
+        {
+            var input = @".clb/*comment*/(@a) { background-image: url(""here.jpg"");}";
+            
+            AssertLessUnchanged (input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        public void CommentNotSupported12 ()
+        {
+            var input = @".clb (/*comment*/@a) { background-image: url(""here.jpg"");}";
+
+            AssertLessUnchanged (input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        public void CommentNotSupported13 ()
+        {
+            var input = @".clb (@a/*comment*/) { background-image: url(""here.jpg"");}";
+
+            AssertLessUnchanged (input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        public void CommentNotSupported14 ()
+        {
+            var input = @".clb (@a,/*comment*/@b) { background-image: url(""here.jpg"");}";
+            
+            AssertLessUnchanged (input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        public void CommentNotSupported15 ()
+        {
+            var input = @".clb (@a,@b/*comment*/) { background-image: url(""here.jpg"");}";
+            
+            AssertLessUnchanged (input);
+        }
+
+        [Test, ExpectedException(typeof(ParserException), ExpectedMessage = @"Comments are not supported in this location", MatchType = MessageMatch.Contains)]
+        [Ignore("Would be nice to detect, but too difficult at the moment - probably easier to fix")]
+        public void CommentNotSupported16 ()
+        {
+            var input = @".clb (@a,@b) /*comment*/ { background-image: url(""here.jpg"");}";
+
+            AssertLessUnchanged (input);
+        }
+	}
+}

--- a/src/dotless.Test/dotless.Test.csproj
+++ b/src/dotless.Test/dotless.Test.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -143,6 +143,7 @@
     <Compile Include="Config\ConfigurationFixture.cs" />
     <Compile Include="Unit\Response\CssResponceFixture.cs" />
     <Compile Include="HttpFixtureBase.cs" />
+    <Compile Include="Unit\Engine\ParserExceptions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\dotless.Core\dotless.Core.csproj">


### PR DESCRIPTION
1. Improve Parser exceptions
2. use the same reg expression in the "tokenizer" as in the parser - It doesn't make sense to be doing quote processing in two different ways. And it lets me detect bad quotes quicker (since the parser regular expression doesn't allow new lines in quotes)
3. Improve the error message when a comment is stopping the parse - where it takes little effort
4. Add tests, including one for the url() data issue
5. The parser was being called twice - Before the try-catch and in it. I really can't think of a reason for it - it meant when the tokenizer failed the error message wasn't very informative.

There are 6 commits shown but only one is in the files changed. I'm having a bit of a nightmare with github - if anyone can help me merge back and eliminate the old commits when I do a pull request, I'd be very greatful.
