### PR TITLE
- Added compression to HTTP handler

### DIFF
--- a/src/dotless.Core/LessCssHttpHandler.cs
+++ b/src/dotless.Core/LessCssHttpHandler.cs
@@ -1,5 +1,6 @@
 ﻿namespace dotless.Core
 {
+    using System.IO.Compression;
     using System.Web;
     using configuration;
     using Microsoft.Practices.ServiceLocation;
@@ -17,6 +18,20 @@
 
         public void ProcessRequest(HttpContext context)
         {
+            string acceptEncoding = (context.Request.Headers["Accept-Encoding"] ?? "").ToUpperInvariant();
+
+            if (acceptEncoding.Contains("GZIP"))
+            {
+                context.Response.AppendHeader("Content-Encoding", "gzip");
+                context.Response.Filter = new GZipStream(context.Response.Filter, CompressionMode.Compress);
+            }
+            else if (acceptEncoding.Contains("DEFLATE"))
+            {
+                context.Response.AppendHeader("Content-Encoding", "deflate");
+                context.Response.Filter = new DeflateStream(context.Response.Filter,
+                                                            CompressionMode.Compress);
+            }
+
             var handler = Container.GetInstance<HandlerImpl>();
             
             handler.Execute();


### PR DESCRIPTION
If the HTTP handler receives a request with accept-encoding: gzip or deflate, it returns the result with the appropriate compression.
