### PR TITLE
Add unit tests from less.js

### DIFF
--- a/src/dotless.Test/Specs/CssFixture.cs
+++ b/src/dotless.Test/Specs/CssFixture.cs
@@ -309,5 +309,27 @@ form[data-disabled] {
 }";
             AssertLessUnchanged(input);
         }
+
+		[Test]
+		[Ignore("Bug in dotless")]
+        public void HttpUrl()
+        {
+			// In MatchAny where we consider if we hit a comment token, instead of changing
+			// it to text we should re-parse the comment?
+			// or does the tokenizer need to be aware of url() as a special case? (see next bug)
+            AssertExpressionUnchanged(@"image: url(http://), ""}"", url(""http://}"")");
+        }
+
+		[Test]
+		[Ignore("Bug in dotless")]
+        public void HttpUrl2()
+        {
+			var input = @".trickyurl {
+image: url(http://); }";
+			var expected = @".trickyurl {
+  image: url(http://);
+}";
+            AssertLess(input, expected);
+        }
     }
 }

--- a/src/dotless.Test/Specs/Functions/FormatStringFixture.cs
+++ b/src/dotless.Test/Specs/Functions/FormatStringFixture.cs
@@ -72,5 +72,92 @@ namespace dotless.Test.Specs.Functions
 
             AssertLess(input, expected);
         }
+
+		[Test]
+		[Ignore("Supported by less.js, not by dotless")]
+		public void EscapeFunction()
+		{
+			var input = @"
+#builtin {
+  @r: 32;
+  escaped: e(""-Some::weird(#thing, y)"");
+}
+";
+			var expected = @"
+#built-in {
+  escaped: -Some::weird(#thing, y);
+}";
+
+			AssertLess(input, expected);
+		}
+
+		[Test]
+		[Ignore("Supported by less.js, not by dotless")]
+		public void ShortFormatFunction()
+		{
+			var input = @"
+#builtin {
+  @r: 32;
+  format: %(""rgb(%d, %d, %d)"", @r, 128, 64);
+}
+";
+			var expected = @"
+#built-in {
+  format: ""rgb(32, 128, 64)"";
+}";
+
+			AssertLess(input, expected);
+		}
+
+		[Test]
+		[Ignore("Supported by less.js, not by dotless")]
+		public void ShortFormatFunctionAcceptingString()
+		{
+			var input = @"
+#builtin {
+  format-string: %(""hello %s"", ""world"");
+}
+";
+			var expected = @"
+#built-in {
+  format-string: ""hello world"";
+}";
+
+			AssertLess(input, expected);
+		}
+
+		[Test]
+		[Ignore("Supported by less.js, not by dotless")]
+		public void ShortFormatFunctionUrlEncode()
+		{
+			var input = @"
+#builtin {
+  format-url-encode: %('red is %A', #ff0000);
+}
+";
+			var expected = @"
+#built-in {
+  format-url-encode: ""red is %23ff0000"";
+}";
+
+			AssertLess(input, expected);
+		}
+
+		[Test]
+		[Ignore("Supported by less.js, not by dotless")]
+		public void EscapeAndShortFormatFunction()
+		{
+			var input = @"
+#builtin {
+  eformat: e(%(""rgb(%d, %d, %d)"", @r, 128, 64));
+}
+";
+			var expected = @"
+#built-in {
+  eformat: rgb(32, 128, 64);
+}";
+
+			AssertLess(input, expected);
+		}
     }
 }

--- a/src/dotless.Test/Specs/MixinsArgsFixture.cs
+++ b/src/dotless.Test/Specs/MixinsArgsFixture.cs
@@ -5,9 +5,34 @@ namespace dotless.Test.Specs
     public class MixinsArgsFixture : SpecFixtureBase
     {
         [Test]
-        public void MixinsArgs()
+        public void MixinsArgsHidden()
         {
-            // Todo: split into separate atomic tests.
+            var input =
+                @"
+.hidden() {
+  color: transparent;
+}
+
+#hidden {
+  .hidden();
+  .hidden;
+}
+";
+
+            var expected =
+                @"
+#hidden {
+  color: transparent;
+  color: transparent;
+}
+";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void MixinsArgsTwoArgs()
+        {
             var input =
                 @"
 .mixin (@a: 1px, @b: 50%) {
@@ -19,68 +44,10 @@ namespace dotless.Test.Specs
     border: @width @style @color;
 }
 
-.mixiny
-(@a: 0, @b: 0) {
-  margin: @a;
-  padding: @b;
-}
-
-.hidden() {
-  color: transparent;
-}
-
 .two-args {
   color: blue;
   .mixin(2px, 100%);
   .mixina(dotted, 2px);
-}
-
-.one-arg {
-  .mixin(3px);
-}
-
-.no-parens {
-  .mixin;
-}
-
-.no-args {
-  .mixin();
-}
-
-.var-args {
-  @var: 9;
-  .mixin(@var, @var * 2);
-}
-
-.multi-mix {
-  .mixin(2px, 30%);
-  .mixiny(4, 5);
-}
-
-.maxa(@arg1: 10, @arg2: #f00) {
-  padding: @arg1 * 2px;
-  color: @arg2;
-}
-
-body {
-  .maxa(15);
-}
-
-@glob: 5;
-.global-mixin(@a:2) {
-  width: @glob + @a;
-}
-
-.scope-mix {
-  .global-mixin(3);
-}
-
-.nested-ruleset (@width: 200px) {
-    width: @width;
-    .column { margin: @width; }
-}
-.content {
-    .nested-ruleset(600px);
 }
 ";
 
@@ -92,35 +59,218 @@ body {
   height: 99%;
   border: 2px dotted black;
 }
+";
+
+            AssertLess(input, expected);
+        }
+
+		[Test]
+        public void MixinsArgsOneArg()
+        {
+            // Todo: split into separate atomic tests.
+            var input =
+                @"
+.mixin (@a: 1px, @b: 50%) {
+  width: @a * 5;
+  height: @b - 1%;
+}
+
+.one-arg {
+  .mixin(3px);
+}
+";
+
+            var expected =
+                @"
 .one-arg {
   width: 15px;
   height: 49%;
 }
+";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void MixinsArgsNoParens()
+        {
+            var input =
+                @"
+.mixin (@a: 1px, @b: 50%) {
+  width: @a * 5;
+  height: @b - 1%;
+}
+.no-parens {
+  .mixin;
+}
+";
+
+            var expected =
+                @"
 .no-parens {
   width: 5px;
   height: 49%;
 }
+";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void MixinsArgsNoArgs()
+        {
+            var input =
+                @"
+.mixin (@a: 1px, @b: 50%) {
+  width: @a * 5;
+  height: @b - 1%;
+}
+
+.no-args {
+  .mixin();
+}
+";
+
+            var expected =
+                @"
 .no-args {
   width: 5px;
   height: 49%;
 }
+";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void MixinsArgsVariableArgs()
+        {
+            var input =
+                @"
+.mixin (@a: 1px, @b: 50%) {
+  width: @a * 5;
+  height: @b - 1%;
+}
+
+.var-args {
+  @var: 9;
+  .mixin(@var, @var * 2);
+}
+";
+
+            var expected =
+                @"
 .var-args {
   width: 45;
   height: 17%;
 }
+";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void MixinsArgsMulti()
+        {
+            var input =
+                @"
+.mixin (@a: 1px, @b: 50%) {
+  width: @a * 5;
+  height: @b - 1%;
+}
+
+.mixiny
+(@a: 0, @b: 0) {
+  margin: @a;
+  padding: @b;
+}
+
+.multi-mix {
+  .mixin(2px, 30%);
+  .mixiny(4, 5);
+}
+";
+
+            var expected =
+                @"
 .multi-mix {
   width: 10px;
   height: 29%;
   margin: 4;
   padding: 5;
 }
+";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void MixinsArgs()
+        {
+            var input =
+                @"
+.maxa(@arg1: 10, @arg2: #f00) {
+  padding: @arg1 * 2px;
+  color: @arg2;
+}
+
+body {
+  .maxa(15);
+}
+";
+
+            var expected =
+                @"
 body {
   padding: 30px;
   color: red;
 }
+";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void MixinsArgsScopeMix()
+        {
+            var input =
+                @"
+@glob: 5;
+.global-mixin(@a:2) {
+  width: @glob + @a;
+}
+
+.scope-mix {
+  .global-mixin(3);
+}
+";
+
+            var expected =
+                @"
 .scope-mix {
   width: 8;
 }
+";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void MixinsArgsNestedRuleset()
+        {
+            var input =
+                @"
+.nested-ruleset (@width: 200px) {
+    width: @width;
+    .column { margin: @width; }
+}
+.content {
+    .nested-ruleset(600px);
+}
+";
+
+            var expected =
+                @"
 .content {
   width: 600px;
 }
@@ -154,7 +304,7 @@ body {
         }
 
         [Test]
-        public void CanUseVaiablesInsideMixins()
+        public void CanUseVariablesInsideMixins()
         {
             var input = @"
 @var: 5px;
@@ -174,7 +324,7 @@ body {
         }
 
         [Test]
-        public void CanUseSameVaiableName()
+        public void CanUseSameVariableName()
         {
             var input =
                 @"
@@ -194,8 +344,75 @@ body {
   radius: 5px;
 }
 ";
-
             AssertLess(input, expected);
         }
+
+		[Test]
+		[Ignore("Supported by less.js, not by dotless")]
+		public void MixinArgsHashMixin()
+		{
+
+			var input = @"
+#id-mixin () {
+    color: red;
+}
+.id-class {
+    #id-mixin();
+    #id-mixin;
+}
+";
+
+			var expected = @"
+.id-class {
+  color: red;
+  color: red;
+}
+";
+			AssertLess(input, expected);
+		}
+
+		[Test]
+		[Ignore("Supported by less.js, not by dotless")]
+		public void MixinArgsArgumentsGiven()
+		{
+
+			var input = @"
+.mixin-arguments (@width: 0px) {
+    border: @arguments;
+}
+
+.arguments {
+    .mixin-arguments(1px, solid, black);
+}
+";
+
+			var expected = @"
+.arguments {
+  border: 1px solid black;
+}
+";
+			AssertLess(input, expected);
+		}
+
+		[Test]
+		[Ignore("Supported by less.js, not by dotless")]
+		public void MixinArgsArgumentsEmpty()
+		{
+
+			var input = @"
+.mixin-arguments (@width: 0px) {
+    border: @arguments;
+}
+.arguments2 {
+    .mixin-arguments();
+}";
+
+			var expected = @"
+.arguments2 {
+  border: 0px;
+}";
+			AssertLess(input, expected);
+		}
+
     }
 }

--- a/src/dotless.Test/Specs/OperationsFixture.cs
+++ b/src/dotless.Test/Specs/OperationsFixture.cs
@@ -38,6 +38,31 @@ namespace dotless.Test.Specs
             AssertExpression("4px", "2px - @z", variables);
         }
 
+		[Test]
+        public void NegationsWorking()
+        {
+            var variables = new Dictionary<string, string>();
+            variables["z"] = "4px";
+
+            AssertExpression("- 4px", "-@z", variables); //ideally should not have space between - and 4
+        }
+
+		[Test]
+		[Ignore("Supported by less.js, not by dotless")]
+        public void NegationsBugs()
+        {
+            var variables = new Dictionary<string, string>();
+            variables["z"] = "4px";
+
+            AssertExpression("0px", "-@z + @z", variables);
+			AssertExpression("0px", "@z + -@z", variables);
+			AssertExpression("8px", "@z - -@z", variables);
+			AssertExpression("0px", "-@z - -@z", variables);
+
+			AssertExpression("- 4px", "-(@z)", variables);
+			AssertExpression("0px", "-(2 + 2) * -@z", variables);
+        }
+
         [Test]
         public void Shorthands()
         {
@@ -67,6 +92,14 @@ namespace dotless.Test.Specs
             AssertExpression("5", "round(10.34) / 2");
             AssertExpression("2", "6 / round(2.8)");
             AssertExpression("50%", "lightness(white) / 2");
+        }
+
+        [Test]
+        public void CanIncludeColorFunctionsInOperations()
+        {
+            AssertExpression("#646464", "rgb(200, 200, 200) / 2");
+            AssertExpression("#ff8080", "2 * hsl(0, 50%, 50%)");
+            AssertExpression("#c94a4a", "rgb(10, 10, 10) + hsl(0, 50%, 50%)");
         }
 
         [Test]

--- a/src/dotless.Test/Specs/StringsFixture.cs
+++ b/src/dotless.Test/Specs/StringsFixture.cs
@@ -36,6 +36,126 @@ namespace dotless.Test.Specs
         }
 
         [Test]
+		[Ignore("Supported by less.js, not by dotless")]
+        public void EscapedWithTilde()
+        {
+            AssertExpression(@"DX.Transform.MS.BS.filter(opacity=50)", @"~""DX.Transform.MS.BS.filter(opacity=50)""");
+        }
+
+        [Test]
+		[Ignore("Supported by less.js, not by dotless")]
+        public void StringInterpolation1()
+        {
+			var input = @"
+#interpolation {
+  @var: '/dev';
+  url: ""http://lesscss.org@{var}/image.jpg"";
+}
+";
+			var expected = @"
+#interpolation {
+  url: ""http://lesscss.org/dev/image.jpg"";
+}";
+
+			AssertLess(input, expected);
+        }
+
+        [Test]
+		[Ignore("Supported by less.js, not by dotless")]
+        public void StringInterpolation2()
+        {
+			var input = @"
+#interpolation {
+  @var2: 256;
+  url2: ""http://lesscss.org/image-@{var2}.jpg"";
+}
+";
+			var expected = @"
+#interpolation {
+  url2: ""http://lesscss.org/image-256.jpg"";
+}";
+
+			AssertLess(input, expected);
+        }
+
+        [Test]
+		[Ignore("Supported by less.js, not by dotless")]
+        public void StringInterpolation3()
+        {
+			var input = @"
+#interpolation {
+  @var3: #456;
+  url3: ""http://lesscss.org@{var3}"";
+}
+";
+			var expected = @"
+#interpolation {
+  url3: ""http://lesscss.org#445566"";
+}";
+
+			AssertLess(input, expected);
+        }
+
+        [Test]
+		[Ignore("Supported by less.js, not by dotless")]
+        public void StringInterpolation4()
+        {
+			var input = @"
+#interpolation {
+  @var4: hello;
+  url4: ""http://lesscss.org/@{var4}"";
+}
+";
+			var expected = @"
+#interpolation {
+  url4: ""http://lesscss.org/hello"";
+}";
+
+			AssertLess(input, expected);
+        }
+
+        [Test]
+		[Ignore("Supported by less.js, not by dotless")]
+        public void StringInterpolation5()
+        {
+			var input = @"
+#interpolation {
+  @var5: 54.4px;
+  url5: ""http://lesscss.org/@{var5}"";
+}
+";
+			var expected = @"
+#interpolation {
+  url5: ""http://lesscss.org/54.4"";
+}";
+
+			AssertLess(input, expected);
+        }
+
+		[Test]
+		[Ignore("Supported by less.js, not by dotless")]
+		public void StringInterpolationMixMulClass()
+		{
+			var input = @".mix-mul (@a: green) {
+    color: ~""@{a}"";
+}
+.mix-mul-class {
+    .mix-mul(blue);
+    .mix-mul(red);
+    .mix-mul(blue);
+    .mix-mul(orange);
+}";
+			var expected = @"
+.mix-mul-class {
+  color: blue;
+  color: red;
+  color: blue;
+  color: orange;
+}";
+			AssertLess(input, expected);
+		}
+
+        [Test]
         public void BracesInQuotes()
         {
             AssertExpressionUnchanged(@"""{"" ""}""");

--- a/src/dotless.Test/Specs/VariablesFixture.cs
+++ b/src/dotless.Test/Specs/VariablesFixture.cs
@@ -5,12 +5,10 @@ namespace dotless.Test.Specs
 
     public class VariablesFixture : SpecFixtureBase
     {
-        [Test]
-        public void Variables()
-        {
-            // Todo: split into separate atomic tests.
-            var input =
-                @"
+		[Test]
+		public void VariableOerators()
+		{
+			var input = @"
 @a: 2;
 @x: @a * @a;
 @y: @x + 1;
@@ -18,21 +16,92 @@ namespace dotless.Test.Specs
 
 .variables {
   width: @z + 1cm; // 14cm
-}
+}";
+			var expected = @"
+.variables {
+  width: 14cm;
+}";
+			AssertLess(input, expected);
+		}
 
-@b: @a * 10;
-@c: #888;
-
+        [Test]
+        public void StringVariables()
+        {
+            var input =
+                @"
 @fonts: ""Trebuchet MS"", Verdana, sans-serif;
 @f: @fonts;
 
+.variables {
+  font-family: @f;
+}
+";
+
+            var expected =
+                @"
+.variables {
+  font-family: ""Trebuchet MS"", Verdana, sans-serif;
+}
+";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void VariablesChangingUnit()
+        {
+            var input =
+                @"
+@a: 2;
+@x: @a * @a;
+@b: @a * 10;
+
+.variables {
+  height: @b + @x + 0px; // 24px
+}
+";
+
+            var expected =
+                @"
+.variables {
+  height: 24px;
+}
+";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void VariablesColor()
+        {
+            var input =
+                @"
+@c: #888;
+
+.variables {
+  color: @c;
+}
+";
+
+            var expected =
+                @"
+.variables {
+  color: #888888;
+}
+";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void VariablesQuoted()
+        {
+            var input =
+                @"
 @quotes: ""~"" ""~"";
 @q: @quotes;
 
 .variables {
-  height: @b + @x + 0px; // 24px
-  color: @c;
-  font-family: @f;
   quotes: @q;
 }
 ";
@@ -40,12 +109,6 @@ namespace dotless.Test.Specs
             var expected =
                 @"
 .variables {
-  width: 14cm;
-}
-.variables {
-  height: 24px;
-  color: #888888;
-  font-family: ""Trebuchet MS"", Verdana, sans-serif;
   quotes: ""~"" ""~"";
 }
 ";
@@ -271,5 +334,82 @@ namespace dotless.Test.Specs
             AssertLess(input, expected);
         }
 
+		[Test]
+		public void VariableValuesMulti()
+		{
+			var input = @"
+.values {
+    @a: 'Trebuchet';
+    font-family: @a, @a, @a;
+}";
+			var expected = @"
+.values {
+  font-family: 'Trebuchet', 'Trebuchet', 'Trebuchet';
+}";
+			AssertLess(input, expected);
+		}
+
+		[Test]
+		[Ignore("Supported by less.js but not dotless")]
+		public void VariableValuesUrl()
+		{
+			var input = @"
+.values {
+    @a: 'Trebuchet';
+    url: url(@a);
+}";
+			var expected = @"
+.values {
+  url: url('Trebuchet');
+}";
+			AssertLess(input, expected);
+		}
+
+		[Test]
+		public void VariableValuesImportant()
+		{
+			var input = @"
+@c: #888;
+.values {
+    color: @c !important;
+}";
+			var expected = @"
+.values {
+  color: #888888 !important;
+}";
+			AssertLess(input, expected);
+		}
+
+		[Test]
+		public void VariableValuesMultipleValues()
+		{
+			var input = @"
+.values {
+    @a: 'Trebuchet';
+    @multi: 'A', B, C;
+    multi: something @multi, @a;
+}";
+			var expected = @"
+.values {
+  multi: something 'A', B, C, 'Trebuchet';
+}";
+			AssertLess(input, expected);
+		}
+
+		[Test]
+		[Ignore("Supported by less.js but not dotless")]
+		public void VariablesNames()
+		{
+			var input = @".variable-names {
+    @var: 'hello';
+    @name: 'var';
+    name: @@name;
+}";
+			var expected = @"
+.variable-names {
+	name: 'hello';
+}";
+			AssertLess(input, expected);
+		}
     }
 }


### PR DESCRIPTION
1. I split up two files with a todo about creating more atomic tests - the tests remain the same and pass, they are just split up
2. Included new tests from less.js, all marked with ignore. They mainly constitute new features (such as ~,%,e). Even if no-one plans to do them in dotless I still think it is good to see them there to mark the difference
3. Include 2 bugs about url() that I will probably fix
