### PR TITLE
Fix build in 2.0

### DIFF
--- a/src/dotless.Core/Parser/Infrastructure/Env.cs
+++ b/src/dotless.Core/Parser/Infrastructure/Env.cs
@@ -59,7 +59,7 @@ namespace dotless.Core.Parser.Infrastructure
                     .GetTypes()
                     .Where(t => functionType.IsAssignableFrom(t) && t != functionType)
                     .Where(t => !t.IsAbstract)
-                    .SelectMany(GetFunctionNames)
+                    .SelectMany<Type, KeyValuePair<string, Type>>(GetFunctionNames)
                     .ToDictionary(p => p.Key, p => p.Value);
 
                 _functionTypes["%"] = typeof (CFormatString);


### PR DESCRIPTION
The type parameters needed to be explicit for it to build in 2.0 and with the build script.
