### PR TITLE
Allow CSS rules before parent selector

### DIFF
--- a/src/dotless.Core/Parser/Parsers.cs
+++ b/src/dotless.Core/Parser/Parsers.cs
@@ -561,7 +561,7 @@ namespace dotless.Core.Parser
             if (e)
                 return NodeProvider.Element(c, e.Value, index);
 
-            if (c.Value.StartsWith("&"))
+            if (c.Value.Contains("&"))
                 return NodeProvider.Element(c, null, index);
 
             return null;


### PR DESCRIPTION
The [SASS documentation](http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#referencing_parent_selectors_) states that you should be able to make a rule like:

``` css
a {
  font-weight: bold;
  body.firefox & { font-weight: normal; }
}
```

and have it compile to:

``` css
a {
  font-weight: bold;
}
body.firefox a {
    font-weight: normal;
}
```

This is especially useful when using a framework like Modernizr, as it applies a ton of classes to the <html> element. But dotless was returning:

``` css
a {
  font-weight: bold;
}
a body.firefox  {
    font-weight: normal;
}
```

(i.e. as if it were "body.firefox &")

I made a one-line change to the parser that allows these inherited rules to be created.
