### PR TITLE
remove last semi-colon in compression

### DIFF
--- a/src/dotless.Core/Parser/Infrastructure/Output.cs
+++ b/src/dotless.Core/Parser/Infrastructure/Output.cs
@@ -158,13 +158,25 @@
             return this;
         }
 
+        /// <summary>
+        ///  Trims whitespace
+        /// </summary>
         public Output Trim()
         {
+            return this.TrimLeft(null).TrimRight(null);
+        }
+
+        /// <summary>
+        /// Trims the character passed or whitespace if it has no value from the left
+        /// </summary>
+        public Output TrimLeft(char? c)
+        {
             int trimLLength = 0;
-            int trimRLength = 0;
             int length = Builder.Length;
 
-            while (trimLLength < length && char.IsWhiteSpace(Builder[trimLLength]))
+            while (trimLLength < length && 
+                    c.HasValue ? Builder[trimLLength] == c.Value : 
+                                char.IsWhiteSpace(Builder[trimLLength]))
             {
                 trimLLength++;
             }
@@ -172,10 +184,22 @@
             if (trimLLength > 0)
             {
                 Builder.Remove(0, trimLLength);
-                length -= trimLLength;
             }
 
-            while (trimRLength < length && char.IsWhiteSpace(Builder[length - (trimRLength + 1)]))
+            return this;
+        }
+
+        /// <summary>
+        /// Trims the character passed or whitespace if it has no value from the left
+        /// </summary>
+        public Output TrimRight(char? c)
+        {
+            int trimRLength = 0;
+            int length = Builder.Length;
+
+            while (trimRLength < length && 
+                   c.HasValue ? Builder[length - (trimRLength + 1)] == c.Value :
+                        char.IsWhiteSpace(Builder[length - (trimRLength + 1)]))
             {
                 trimRLength++;
             }
@@ -187,6 +211,7 @@
 
             return this;
         }
+
 
         public override string ToString()
         {

--- a/src/dotless.Core/Parser/Tree/Ruleset.cs
+++ b/src/dotless.Core/Parser/Tree/Ruleset.cs
@@ -132,6 +132,11 @@ namespace dotless.Core.Parser.Tree
         /// </summary>
         protected void AppendRules(Env env)
         {
+            if (env.Compress && Rules.Count == 0)
+            {
+                return;
+            }
+
             env.Output
                 .Append(env.Compress ? "{" : " {\n")
 
@@ -139,9 +144,14 @@ namespace dotless.Core.Parser.Tree
                 .AppendMany(Rules, "\n")
                 .Trim()
                 .Indent(env.Compress ? 0 : 2)
-                .PopAndAppend()
+                .PopAndAppend();
 
-                .Append(env.Compress ? "}" : "\n}");
+            if (env.Compress)
+            {
+                env.Output.TrimRight(';');
+            }
+
+            env.Output.Append(env.Compress ? "}" : "\n}");
         }
 
         protected virtual void AppendCSS(Env env, Context context)
@@ -210,6 +220,11 @@ namespace dotless.Core.Parser.Tree
                     env.Output.Append(env.Compress ? "{" : " {\n  ");
 
                     env.Output.AppendMany(rules, env.Compress ? "" : "\n  ");
+
+                    if (env.Compress)
+                    {
+                        env.Output.TrimRight(';');
+                    }
 
                     env.Output.Append(env.Compress ? "}" : "\n}\n");
 

--- a/src/dotless.Test/SpecFixtureBase.cs
+++ b/src/dotless.Test/SpecFixtureBase.cs
@@ -120,7 +120,7 @@
                 return "";
 
             var start = css.IndexOf("expression:");
-            var end = css.LastIndexOf(";");
+            var end =  css.LastIndexOf(DefaultEnv().Compress ? '}' : ';');
 
             return css.Substring(start + 11, end - start - 11).Trim();
         }

--- a/src/dotless.Test/Specs/Compression/CommentsFixture.cs
+++ b/src/dotless.Test/Specs/Compression/CommentsFixture.cs
@@ -20,7 +20,7 @@ namespace dotless.Test.Specs.Compression
             //  e.g. it does not count toward the descendent selector. IE7 Quirks applies both .cls.cla and .cls .cla
             var input = @".cls/* COMMENT */.cla {background-image: url(pickture.asp);}";
 
-            var expected = @".cls.cla{background-image:url(pickture.asp);}";
+            var expected = @".cls.cla{background-image:url(pickture.asp)}";
 
             AssertLess(input, expected);
         }
@@ -30,7 +30,7 @@ namespace dotless.Test.Specs.Compression
         {
             var input = @".cls/* COMMENT */ + /* COMMENT */.cla {background-image: url(pickture.asp);}";
 
-            var expected = @".cls+.cla{background-image:url(pickture.asp);}";
+            var expected = @".cls+.cla{background-image:url(pickture.asp)}";
 
             AssertLess(input, expected);
         }
@@ -40,7 +40,7 @@ namespace dotless.Test.Specs.Compression
         {
             var input = @".cls /* COMMENT *//* COMMENT */.cla {background-image: url(pickture.asp);}";
 
-            var expected = @".cls .cla{background-image:url(pickture.asp);}";
+            var expected = @".cls .cla{background-image:url(pickture.asp)}";
 
             AssertLess(input, expected);
         }
@@ -50,7 +50,7 @@ namespace dotless.Test.Specs.Compression
         {
             var input = @".cls/* COMMENT */ /* COMMENT */.cla {background-image: url(pickture.asp);}";
 
-            var expected = @".cls .cla{background-image:url(pickture.asp);}";
+            var expected = @".cls .cla{background-image:url(pickture.asp)}";
 
             AssertLess(input, expected);
         }
@@ -60,7 +60,7 @@ namespace dotless.Test.Specs.Compression
         {
             var input = @".cls/* COMMENT *//* COMMENT */ .cla {background-image: url(pickture.asp);}";
 
-            var expected = @".cls .cla{background-image:url(pickture.asp);}";
+            var expected = @".cls .cla{background-image:url(pickture.asp)}";
 
             AssertLess(input, expected);
         }
@@ -80,7 +80,7 @@ namespace dotless.Test.Specs.Compression
         /* color: #fff; */
     }
 }";
-            var expected = @".wrapper .header{font-weight:bold;}";
+            var expected = @".wrapper .header{font-weight:bold}";
 
             AssertLess(input, expected);
         }

--- a/src/dotless.Test/Specs/Compression/ImportFixture.cs
+++ b/src/dotless.Test/Specs/Compression/ImportFixture.cs
@@ -54,7 +54,7 @@ namespace dotless.Test.Specs.Compression
 }
 ";
 
-            var expected = "@import \"import-test-d.css\";#import{color:red;}.mixin{height:10px;color:red;}#import-test{height:10px;color:red;width:10px;height:30%;}";
+            var expected = "@import \"import-test-d.css\";#import{color:red}.mixin{height:10px;color:red}#import-test{height:10px;color:red;width:10px;height:30%}";
 
             var parser = GetParser();
 

--- a/src/dotless.Test/Specs/Compression/SelectorsFixture.cs
+++ b/src/dotless.Test/Specs/Compression/SelectorsFixture.cs
@@ -18,7 +18,7 @@ h1, h2, h3 {
 }
 ";
 
-            var expected = "h1 a:hover,h2 a:hover,h3 a:hover,h1 p:hover,h2 p:hover,h3 p:hover{color:red;}";
+            var expected = "h1 a:hover,h2 a:hover,h3 a:hover,h1 p:hover,h2 p:hover,h3 p:hover{color:red}";
 
             AssertLess(input, expected);
         }
@@ -33,7 +33,7 @@ h1, h2, h3 {
 #same { color: blue; }
 ";
 
-            var expected = "#all{color:blue;}#the{color:blue;}#same{color:blue;}";
+            var expected = "#all{color:blue}#the{color:blue}#same{color:blue}";
 
             AssertLess(input, expected);
         }
@@ -48,7 +48,7 @@ td {
 }
 ";
 
-            var expected = "td{margin:0;padding:0;}";
+            var expected = "td{margin:0;padding:0}";
 
             AssertLess(input, expected);
         }
@@ -62,7 +62,7 @@ td, input {
 }
 ";
 
-            var expected = "td,input{line-height:1em;}";
+            var expected = "td,input{line-height:1em}";
 
             AssertLess(input, expected);
         }
@@ -77,7 +77,7 @@ ul, li, div, q, blockquote, textarea {
 }
 ";
 
-            var expected = "ul,li,div,q,blockquote,textarea{margin:0;}";
+            var expected = "ul,li,div,q,blockquote,textarea{margin:0}";
 
             AssertLess(input, expected);
         }
@@ -88,7 +88,7 @@ ul, li, div, q, blockquote, textarea {
         {
             var input = "td \t input { line-height: 1em; }";
 
-            var expected = "td input{line-height:1em;}";
+            var expected = "td input{line-height:1em}";
 
             AssertLess(input, expected);
         }

--- a/src/dotless.Test/Specs/Compression/WhitespaceFixture.cs
+++ b/src/dotless.Test/Specs/Compression/WhitespaceFixture.cs
@@ -23,7 +23,7 @@ white;
 .whitespace { color : white; }
 ";
 
-            var expected = ".whitespace{color:white;}.whitespace{color:white;}.whitespace{color:white;}.whitespace{color:white;}.whitespace{color:white;}";
+            var expected = ".whitespace{color:white}.whitespace{color:white}.whitespace{color:white}.whitespace{color:white}.whitespace{color:white}";
 
             AssertLess(input, expected);
         }
@@ -41,7 +41,7 @@ white;
         white;
 }";
 
-            var expected = ".white,.space,.mania{color:white;}";
+            var expected = ".white,.space,.mania{color:white}";
 
             AssertLess(input, expected);
         }
@@ -51,7 +51,7 @@ white;
         {
             var input = ".no-semi-colon { color: white }";
 
-            var expected = ".no-semi-colon{color:#fff;}";
+            var expected = ".no-semi-colon{color:#fff}";
 
             AssertLess(input, expected);
         }
@@ -65,7 +65,7 @@ white;
   white-space: pre
 }";
 
-            var expected = ".no-semi-colon{color:white;white-space:pre;}";
+            var expected = ".no-semi-colon{color:white;white-space:pre}";
 
             AssertLess(input, expected);
         }
@@ -75,7 +75,7 @@ white;
         {
             var input = ".no-semi-colon {border: 2px solid white}";
 
-            var expected = ".no-semi-colon{border:2px solid #fff;}";
+            var expected = ".no-semi-colon{border:2px solid #fff}";
 
             AssertLess(input, expected);
         }
@@ -95,7 +95,7 @@ great,
           black;
 }";
 
-            var expected = ".newlines{background:the, great, wall;border:2px solid black;}";
+            var expected = ".newlines{background:the, great, wall;border:2px solid black}";
 
             AssertLess(input, expected);
         }


### PR DESCRIPTION
What do you think?

In response to https://github.com/dotless/dotless/issues/60 from @replete

I can't see any reason why it would be risky, it would put my mind at risk if the big css compressors do this or if there is a reason not to (standards compliance?)

If there is a reason not too I could make it an option?
