### PR TITLE
Better prettifying of comments before selectors

### DIFF
--- a/src/dotless.Core/Parser/Parsers.cs
+++ b/src/dotless.Core/Parser/Parsers.cs
@@ -83,7 +83,13 @@ namespace dotless.Core.Parser
 
                 comments = node as NodeList;
                 if (comments)
+                {
+                    foreach (Comment c in comments)
+                    {
+                        c.IsPreSelectorComment = true;
+                    }
                     root.AddRange(comments);
+                }
                 else
                     root.Add(node);
 
@@ -726,6 +732,7 @@ namespace dotless.Core.Parser
             var elements = new NodeList<Element>();
             var index = parser.Tokenizer.Location.Index;
 
+            GatherComments(parser);
             PushComments();
 
             while (true)

--- a/src/dotless.Core/Parser/Tree/Comment.cs
+++ b/src/dotless.Core/Parser/Tree/Comment.cs
@@ -7,6 +7,7 @@
     {
         public string Value { get; set; }
         public bool Silent { get; set; }
+        public bool IsPreSelectorComment { get; set; }
         private bool IsCSSHack { get; set; }
 
         public Comment(string value, bool silent)
@@ -19,7 +20,14 @@
         public override void AppendCSS(Env env)
         {
             if (!Silent && (!env.Compress || IsCSSHack))
+            {
                 env.Output.Append(Value);
+
+                if (!env.Compress && !IsCSSHack && IsPreSelectorComment)
+                {
+                    env.Output.Append("\n");
+                }
+            }
         }
     }
 }

--- a/src/dotless.Test/Specs/CommentsFixture.cs
+++ b/src/dotless.Test/Specs/CommentsFixture.cs
@@ -428,7 +428,8 @@ border: solid black;
             // Note: https://github.com/dotless/dotless/issues/31
             var input = @"/* COMMENT */body/* COMMENT */,/* COMMENT */ .clb /* COMMENT */ {background-image: url(pickture.asp);}";
 
-            var expected = @"/* COMMENT */body/* COMMENT */, /* COMMENT */ .clb/* COMMENT */ {
+            var expected = @"/* COMMENT */
+body/* COMMENT */, /* COMMENT */ .clb/* COMMENT */ {
   background-image: url(pickture.asp);
 }";
 
@@ -441,7 +442,8 @@ border: solid black;
             // Note: https://github.com/dotless/dotless/issues/31
             var input = @"/* COMMENT */body/* COMMENT */, /* COMMENT */.cls/* COMMENT */ .cla,/* COMMENT */ .clb /* COMMENT */ {background-image: url(pickture.asp);}";
 
-            var expected = @"/* COMMENT */body/* COMMENT */, /* COMMENT */ .cls/* COMMENT */ .cla, /* COMMENT */ .clb/* COMMENT */ {
+            var expected = @"/* COMMENT */
+body/* COMMENT */, /* COMMENT */ .cls/* COMMENT */ .cla, /* COMMENT */ .clb/* COMMENT */ {
   background-image: url(pickture.asp);
 }";
 
@@ -515,7 +517,8 @@ border: solid black;
             var input = @"/* COMMENT */@a : 10px;/* COMMENT */
 .cla { font-size: @a; }";
 
-            var expected = @"/* COMMENT *//* COMMENT */.cla {
+            var expected = @"/* COMMENT *//* COMMENT */
+.cla {
   font-size: 10px;
 }";
 
@@ -528,7 +531,8 @@ border: solid black;
             var input = @"/* COM1 */@a /* COM2 */: /* COM3 */10px/* COM4 */;/* COM5 */
 .cla { font-size: @a; }";
 
-            var expected = @"/* COM1 *//* COM5 */.cla {
+            var expected = @"/* COM1 *//* COM5 */
+.cla {
   font-size: /* COM3 */10px/* COM4 */;
 }";
 
@@ -540,7 +544,8 @@ border: solid black;
         {
             var input = @"/* COMMENT */@charset /* COMMENT */""utf-8""/* COMMENT */;";
 
-            var expected = @"/* COMMENT */@charset /* COMMENT */""utf-8""/* COMMENT */;";
+            var expected = @"/* COMMENT */
+@charset /* COMMENT */""utf-8""/* COMMENT */;";
 
             AssertLess(input, expected);
         }
@@ -560,7 +565,8 @@ border: solid black;
   /*COM3*/
   font-size: 3em;
 }
-/*COM 6*/@font-face/*COM4*/ {
+/*COM 6*/
+@font-face/*COM4*/ {
   /*COM5*/
   font-size: 3em;
 }

--- a/src/dotless.Test/Unit/Engine/CommentBug.cs
+++ b/src/dotless.Test/Unit/Engine/CommentBug.cs
@@ -18,9 +18,11 @@ body
 }";
 
             var expected =
-                @"/* Block comment ********************/body {
+                @"/* Block comment ********************/
+body {
   background-color: yellow;
   /* Another block comment */
+
 }";
 
             AssertLess(input, expected);


### PR DESCRIPTION
My comments change stopped adding a newline after comments before selectors..

Previous to my last comments change comments were picked up as rules in the root, where as now they are part of the selector. 

In order to keep a css hack comment at the begining of a selector without a newline, a newline is now added if it is a comment before a selector and it isn't recognised as a css hack.

@tigraine looking at the unit tests I've changed does this fix the issue brought up on the mailing list?
