### PR TITLE
support document

### DIFF
--- a/src/dotless.Core/Parser/Parsers.cs
+++ b/src/dotless.Core/Parser/Parsers.cs
@@ -943,17 +943,22 @@ namespace dotless.Core.Parser
             bool hasIdentifier = false, hasBlock = false, isKeyFrame = false;
             NodeList rules, preRulesComments = null, preComments = null;
             string identifierRegEx = @"[^{]+";
+            string nonVendorSpecificName = name;
 
-            switch (name)
+            if (name.StartsWith("@-") && name.IndexOf('-', 2) > 0)
             {
-                case "@media":
-                    hasIdentifier = true;
-                    hasBlock = true;
-                    break;
+                nonVendorSpecificName = "@" + name.Substring(name.IndexOf('-', 2) + 1);
+            }
+
+            switch (nonVendorSpecificName)
+            {
                 case "@font-face":
                     hasBlock = true;
                     break;
                 case "@page":
+                case "@document":
+                case "@media":
+                case "@supports":
                     hasBlock = true;
                     hasIdentifier = true;
                     break;
@@ -976,8 +981,6 @@ namespace dotless.Core.Parser
                     hasBlock = true;
                     break;
                 case "@keyframes":
-                case "@-webkit-keyframes":
-                case "@-moz-keyframes":
                     isKeyFrame = true;
                     hasIdentifier = true;
                     break;
@@ -991,10 +994,10 @@ namespace dotless.Core.Parser
             {
                 GatherComments(parser);
 
-                identifier = parser.Tokenizer.MatchString(identifierRegEx);
-                if (identifier != null)
+                var identifierRegResult = parser.Tokenizer.MatchAny(identifierRegEx);
+                if (identifierRegResult != null)
                 {
-                    identifier = identifier.Trim();
+                    identifier = identifierRegResult.Value.Trim();
                 }
             }
 

--- a/src/dotless.Test/Specs/CommentsFixture.cs
+++ b/src/dotless.Test/Specs/CommentsFixture.cs
@@ -555,8 +555,10 @@ border: solid black;
   font-size: 3em;
 }/*COM 6*/
 ";
-
-            var expected = @"@media print/*COM1*//*COM2*/ {
+            // com1 and com2 the wrong way round because CommentsInDirective3 test fails..
+            // we don't support directives very well, so com2 gets parsed as the identifier
+            // and the comment before gets stuck on afterwards..
+            var expected = @"@media print /*COM2*//*COM1*/ {
   /*COM3*/
   font-size: 3em;
 }

--- a/src/dotless.Test/Specs/Css3Fixture.cs
+++ b/src/dotless.Test/Specs/Css3Fixture.cs
@@ -100,6 +100,59 @@ namespace dotless.Test.Specs
         }
 
         [Test]
+        public void SupportMozDocument()
+        {
+            // see https://github.com/dotless/dotless/issues/73
+            var input =
+                @"
+@-moz-document url-prefix(""https://github.com"") {
+  h1 {
+    color: red;
+  }
+}
+";
+
+            AssertLessUnchanged(input);
+        }
+
+        [Test]
+        public void SupportVendorXDocument()
+        {
+            var input =
+                @"
+@-x-document url-prefix(""github.com"") {
+  h1 {
+    color: red;
+  }
+}
+";
+
+            AssertLessUnchanged(input);
+        }
+
+        [Test]
+        public void SupportSupports()
+        {
+            // example from http://www.w3.org/TR/2011/WD-css3-conditional-20110901/
+            var input =
+                @"
+@supports ( box-shadow: 2px 2px 2px black ) or
+          ( -moz-box-shadow: 2px 2px 2px black ) or
+          ( -webkit-box-shadow: 2px 2px 2px black ) or
+          ( -o-box-shadow: 2px 2px 2px black ) {
+  .outline {
+    color: white;
+    box-shadow: 2px 2px 2px black;
+    -moz-box-shadow: 2px 2px 2px black;
+    -webkit-box-shadow: 2px 2px 2px black;
+    -o-box-shadow: 2px 2px 2px black;
+  }
+}";
+
+            AssertLessUnchanged(input);
+        }
+
+        [Test]
         public void MediaDirectiveCanHavePageDirective1()
         {
             // see https://github.com/dotless/dotless/issues/27


### PR DESCRIPTION
fixes https://github.com/dotless/dotless/issues/73

Note: as @axefrog suggests, we cannot support generic directives because directive interfere with less - so they have to be added manually.

I've made all the directives support any vendor prefix and added @supports from the css spec.
