### PR TITLE
Wrap format exception as a parser exception to generate a better error me

### DIFF
--- a/src/dotless.Core/Parser/Functions/FormatStringFunction.cs
+++ b/src/dotless.Core/Parser/Functions/FormatStringFunction.cs
@@ -5,6 +5,7 @@ namespace dotless.Core.Parser.Functions
     using Infrastructure;
     using Infrastructure.Nodes;
     using Tree;
+    using dotless.Core.Exceptions;
 
     public class FormatStringFunction : Function
     {
@@ -19,7 +20,16 @@ namespace dotless.Core.Parser.Functions
 
             var args = Arguments.Skip(1).Select(unescape).ToArray();
 
-            var result = string.Format(format, args);
+            string result;
+
+            try
+            {
+                result = string.Format(format, args);
+            }
+            catch (FormatException e)
+            {
+                throw new ParserException(string.Format("Error in formatString :{0}", e.Message), e);
+            }
 
             return new Quoted(result, false);
         }

--- a/src/dotless.Test/Specs/Functions/FormatStringFixture.cs
+++ b/src/dotless.Test/Specs/Functions/FormatStringFixture.cs
@@ -20,9 +20,21 @@ namespace dotless.Test.Specs.Functions
         }
 
         [Test]
-        public void SubsequentArgumentssIgnored()
+        public void SubsequentArgumentsIgnored()
         {
             AssertExpression("abc", "formatstring('abc', 'd', 'e')");
+        }
+
+        [Test, ExpectedException(typeof(dotless.Core.Exceptions.ParserException))]
+        public void ExceptionOnMissingArguments1()
+        {
+            AssertExpression("abc", "formatstring('abc{0}')");
+        }
+
+        [Test, ExpectedException(typeof(dotless.Core.Exceptions.ParserException))]
+        public void ExceptionOnMissingArguments2()
+        {
+            AssertExpression("abc", "formatstring('{2}abc')");
         }
 
         [Test]


### PR DESCRIPTION
Wrap format exception as a parser exception to generate a better error message
