### PR TITLE
dont restrict calling a mixin of the same name within the same frame scop

### DIFF
--- a/src/dotless.Core/Parser/Infrastructure/Env.cs
+++ b/src/dotless.Core/Parser/Infrastructure/Env.cs
@@ -42,12 +42,12 @@
             return null;
         }
 
-        public List<Closure> FindRulesets(Selector selector)
+        public IEnumerable<Closure> FindRulesets(Selector selector)
         {
             return Frames.Select(frame => frame.Find(this, selector, null))
-                .Where(matchedClosuresList => !matchedClosuresList.Any(
-                            matchedClosure => Frames.Any(frame => frame.IsEqualOrClonedFrom(matchedClosure.Ruleset))))
-                .FirstOrDefault(matchedClosuresList => matchedClosuresList.Count != 0);
+                .Select(matchedClosuresList => matchedClosuresList.Where(
+                            matchedClosure => !Frames.Any(frame => frame.IsEqualOrClonedFrom(matchedClosure.Ruleset))))
+                .FirstOrDefault(matchedClosuresList => matchedClosuresList.Count() != 0);
         }
 
         public virtual Function GetFunction(string name)

--- a/src/dotless.Test/Specs/MixinsFixture.cs
+++ b/src/dotless.Test/Specs/MixinsFixture.cs
@@ -487,6 +487,34 @@ namespace dotless.Test.Specs
         }
 
         [Test]
+        public void OverrideMixinToAddNonSimpleDefaultArguments()
+        {
+            // see https://github.com/dotless/dotless/issues/79
+
+            var input = @"
+.gradient(@from, @to)
+{
+    background: -moz-linear-gradient(@from, @to);
+}
+
+.gradient(@colour) {
+    .gradient(@colour, darken(@colour, 10%));
+}
+
+.test {
+    .gradient(#aaaaaa);
+}";
+
+
+            var expected = @"
+.test {
+  background: -moz-linear-gradient(#aaaaaa, #909090);
+}
+";
+            AssertLess(input, expected);
+        }
+
+        [Test]
         public void MixinWithArgsInsideNamespace()
         {
             var input =


### PR DESCRIPTION
dont restrict calling a mixin of the same name within the same frame scope as the current mixin

This might present a merge challenge with a different fix I've requested to be merged.

Basically instead of cutting out the context list if it contains a context with the same ruleset as the current, this just cuts out contexts which are the same as the current. This stops self referencing but allows calling a mixin with a different argument context.

I renamed the variables in the same was as the other pull request, so that should make merging it easier.
