### PR TITLE
Allow Capital Properties

### DIFF
--- a/src/dotless.Core/Parser/Parsers.cs
+++ b/src/dotless.Core/Parser/Parsers.cs
@@ -1291,7 +1291,7 @@ namespace dotless.Core.Parser
 
         public string Property(Parser parser)
         {
-            var name = parser.Tokenizer.Match(@"\*?-?[-_a-z][-_a-z0-9]*");
+            var name = parser.Tokenizer.Match(@"\*?-?[-_a-zA-Z][-_a-z0-9A-Z]*");
 
             if (name)
                 return name.Value;

--- a/src/dotless.Test/Specs/CssFixture.cs
+++ b/src/dotless.Test/Specs/CssFixture.cs
@@ -226,6 +226,22 @@ p {
         }
 
         [Test]
+        public void CapitalProperties()
+        {
+            var input =
+                @"
+.misc {
+  -Moz-Border-Radius: 2Px;
+  dISplay: NONE;
+  WIDTH: .1EM;
+}
+";
+
+            AssertLessUnchanged(input);
+        }
+
+
+        [Test]
         public void Important()
         {
             var input =


### PR DESCRIPTION
Allows

BACKGROUND: black;

.. I wouldn't reccomend caps but I don't see any reason to disallow it. See bug #96
