### PR TITLE
Make imports fall back on inserting into document unless ending in .less

### DIFF
--- a/src/dotless.Core/Importers/Importer.cs
+++ b/src/dotless.Core/Importers/Importer.cs
@@ -26,12 +26,27 @@ namespace dotless.Core.Importers
             Imports = new List<string>();
         }
 
-        public virtual void Import(Import import)
+        /// <summary>
+        ///  Imports the file inside the import as a dot-less file.
+        /// </summary>
+        /// <param name="import"></param>
+        /// <returns> Whether the file was found - so false if it cannot be found</returns>
+        public virtual bool Import(Import import)
         {
             if (Parser == null)
                 throw new InvalidOperationException("Parser cannot be null.");
 
             var file = Paths.Concat(new[] { import.Path }).AggregatePaths();
+
+            if (!FileReader.DoesFileExist(file) && !file.EndsWith(".less"))
+            {
+                file = file + ".less";
+            }
+
+            if (!FileReader.DoesFileExist(file))
+            {
+                return false;
+            }
 
             var contents = FileReader.GetFileContents(file);
 
@@ -51,6 +66,8 @@ namespace dotless.Core.Importers
             {
                 Paths.RemoveAt(Paths.Count - 1);
             }
+
+            return true;
         }
     }
 }

--- a/src/dotless.Core/Input/FileReader.cs
+++ b/src/dotless.Core/Input/FileReader.cs
@@ -21,5 +21,12 @@ namespace dotless.Core.Input
 
             return File.ReadAllText(fileName);
         }
+
+        public bool DoesFileExist(string fileName)
+        {
+            fileName = PathResolver.GetFullPath(fileName);
+
+            return File.Exists(fileName);
+        }
     }
 }

--- a/src/dotless.Core/Input/IFileReader.cs
+++ b/src/dotless.Core/Input/IFileReader.cs
@@ -3,5 +3,7 @@ namespace dotless.Core.Input
     public interface IFileReader
     {
         string GetFileContents(string fileName);
+
+        bool DoesFileExist(string fileName);
     }
 }

--- a/src/dotless.Core/Input/VirtualFileReader.cs
+++ b/src/dotless.Core/Input/VirtualFileReader.cs
@@ -14,5 +14,11 @@ namespace dotless.Core.Input
                 return streamReader.ReadToEnd();
             }
         }
+
+        public bool DoesFileExist(string fileName)
+        {
+            var virtualPathProvider = HostingEnvironment.VirtualPathProvider;
+            return virtualPathProvider.GetFile(fileName) != null;
+        }
     }
 }

--- a/src/dotless.Core/Parser/Tree/Import.cs
+++ b/src/dotless.Core/Parser/Tree/Import.cs
@@ -6,6 +6,7 @@ namespace dotless.Core.Parser.Tree
     using Infrastructure.Nodes;
     using Utils;
     using System.Collections.Generic;
+    using System;
 
     public class Import : Directive
     {
@@ -30,14 +31,20 @@ namespace dotless.Core.Parser.Tree
         private Import(string path, Importer importer)
         {
             Importer = importer;
-            var regex = new Regex(@"\.(le|c)ss$");
+            Path = path;
 
-            Path = regex.IsMatch(path) ? path : path + ".less";
+            if (path.EndsWith(".css"))
+            {
+                Css = true;
+            } else
+            {
+                Css = !Importer.Import(this); // it is assumed to be css if it cannot be found as less
 
-            Css = Path.EndsWith("css");
-
-            if(!Css)
-                Importer.Import(this);
+                if (Css && path.EndsWith(".less"))
+                {
+                    throw new Exception("You are importing a file ending in .less that cannot be found");
+                }
+            }
         }
 
         protected override void AppendCSS(Env env, Context context)

--- a/src/dotless.Test/Config/ConfigurationFixture.cs
+++ b/src/dotless.Test/Config/ConfigurationFixture.cs
@@ -247,6 +247,11 @@ namespace dotless.Test.Config
             {
                 throw new NotImplementedException();
             }
+
+            public bool DoesFileExist(string fileName)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/dotless.Test/DictionaryReader.cs
+++ b/src/dotless.Test/DictionaryReader.cs
@@ -27,5 +27,10 @@ namespace dotless.Test
 
             throw new FileNotFoundException(string.Format("Import {0} not found", fileName), fileName);
         }
+
+        public bool DoesFileExist(string fileName)
+        {
+            return Contents.ContainsKey(fileName);
+        }
     }
 }

--- a/src/dotless.Test/SpecFixtureBase.cs
+++ b/src/dotless.Test/SpecFixtureBase.cs
@@ -70,6 +70,11 @@
             Assert.That(() => Evaluate(input), Throws.Exception.Message.EqualTo(message));
         }
 
+        protected void AssertError(string message, string input, Parser parser)
+        {
+            Assert.That(() => Evaluate(input, parser), Throws.Exception.Message.EqualTo(message));
+        }
+
         public void AssertError(string message, string line, int lineNumber, int position, string input)
         {
             AssertError(message, line, lineNumber, position, null, 0, input);

--- a/src/dotless.Test/Specs/Compression/ImportFixture.cs
+++ b/src/dotless.Test/Specs/Compression/ImportFixture.cs
@@ -60,5 +60,73 @@ namespace dotless.Test.Specs.Compression
 
             AssertLess(input, expected, parser);
         }
+
+        [Test]
+        public void ImportFleExtensionNotNecessary()
+        {
+            var input =
+                @"
+@import url(""import/import-test-c"");
+";
+
+            var expected = "@import \"import-test-d.css\";#import{color:red;}";
+
+            var parser = GetParser();
+
+            AssertLess(input, expected, parser);
+        }
+
+        [Test]
+        public void ImportForUrlGetsOutput()
+        {
+            var input =
+                @"
+@import url(""http://www.someone.com/external1.css"");@import ""http://www.someone.com/external2.css"";
+";
+
+            var parser = GetParser();
+
+            AssertLessUnchanged(input, parser);
+        }
+
+        [Test]
+        public void ImportForMissingLessFileThrowsError1()
+        {
+            var input =
+                @"
+@import url(""http://www.someone.com/external1.less"");
+";
+
+            var parser = GetParser();
+
+            AssertError("You are importing a file ending in .less that cannot be found", input, parser);
+        }
+
+        [Test]
+        public void ImportForMissingLessFileThrowsError2()
+        {
+            var input =
+                @"
+@import ""external1.less"";
+";
+
+            var parser = GetParser();
+
+            AssertError("You are importing a file ending in .less that cannot be found", input, parser);
+        }
+
+        [Test]
+        public void ImportForMissingLessFileThrowsError3()
+        {
+            var input =
+                @"
+@import ""http://www.someone.com/external1.less"";
+";
+
+            var parser = GetParser();
+
+            AssertError("You are importing a file ending in .less that cannot be found", input, parser);
+        }
+
     }
 }


### PR DESCRIPTION
so if the import does not end in .less and cannot be read as a file we should fallback on inserting it as an @import.

This came up on the mailing list when someone wanted to import

@import "http://fonts.googleapis.com/css?family=Oswald";

the work-around is to do...

@import "http://fonts.googleapis.com/css?family=Oswald&ignore=.css";

But this fixes this issue. See the unit tests added for more detail.
