### PR TITLE
Auto-creation of the output directory

### DIFF
--- a/src/dotless.Compiler/Program.cs
+++ b/src/dotless.Compiler/Program.cs
@@ -109,6 +109,7 @@ namespace dotless.Compiler
                 Console.WriteLine("{0} -> {1}", inputFilePath, outputFilePath);
                 var directoryPath = Path.GetDirectoryName(inputFilePath);
                 var source = new dotless.Core.Input.FileReader().GetFileContents(inputFilePath);
+                Directory.CreateDirectory(directoryPath);
                 Directory.SetCurrentDirectory(directoryPath);
                 var css = engine.TransformToCss(source, inputFilePath);
                 if (string.IsNullOrEmpty(css) && !string.IsNullOrEmpty(source))


### PR DESCRIPTION
The output directory should be created automatically when it doesn't exist. This is handy when using the VS publishing with the option "Delete all existing files prior to publish". And in my case the dotLess compiler crashes in 10% of the builds with DirectoryNotFoundException even when I have additional build-event steps to create the directory in advance.
