### PR TITLE
Auto-creation of the output directory

### DIFF
--- a/src/dotless.Compiler/Program.cs
+++ b/src/dotless.Compiler/Program.cs
@@ -45,7 +45,13 @@ namespace dotless.Compiler
             }
             
             if (string.IsNullOrEmpty(outputDirectoryPath))
+            {
                 outputDirectoryPath = inputDirectoryPath;
+            }
+            else
+            {
+                Directory.CreateDirectory(outputDirectoryPath);
+            }
 
             if (HasWildcards(inputFilePattern)) 
                 outputFilename = string.Empty;


### PR DESCRIPTION
The output directory should be created automatically when it doesn't exist. This is handy when using the VS publishing with the option "Delete all existing files prior to publish". And in my case the dotLess compiler crashes in 10% of the builds with DirectoryNotFoundException even when I have additional build-event steps to create the directory in advance.
