### PR TITLE
Fix build error

### DIFF
--- a/src/dotless.Test/Specs/ImportFixture.cs
+++ b/src/dotless.Test/Specs/ImportFixture.cs
@@ -7,7 +7,12 @@ namespace dotless.Test.Specs
 
     public class ImportFixture : SpecFixtureBase
     {
-        private static Parser GetParser(bool isUrlRewritingDisabled = false)
+        private static Parser GetParser()
+        {
+            return GetParser(false);
+        }
+
+        private static Parser GetParser(bool isUrlRewritingDisabled)
         {
             var imports = new Dictionary<string, string>();
 


### PR DESCRIPTION
Refactored code in /src/tests/specs/ImportFixture.cs to avoid "Default parameter specifiers are not permitted" error message. Overloaded GetParser() method.
