### PR TITLE
Minor fixes

### DIFF
--- a/default.build
+++ b/default.build
@@ -218,6 +218,7 @@
 
 
 <script language="C#" prefix="process">
+  <references><include name="system.dll"/></references>
   <code>
     <![CDATA[
       [Function("git")]

--- a/src/dotless.Core/Parser/Parser.cs
+++ b/src/dotless.Core/Parser/Parser.cs
@@ -108,7 +108,7 @@ namespace dotless.Core.Parser
         }
 
         public Parser(int optimization, IStylizer stylizer, IImporter importer)
-            : this(defaultOptimization, stylizer, importer, defaultDebug)
+            : this(optimization, stylizer, importer, defaultDebug)
         {
         }
 

--- a/src/dotless.Core/Plugins/PluginParameter.cs
+++ b/src/dotless.Core/Plugins/PluginParameter.cs
@@ -1,6 +1,7 @@
 ﻿namespace dotless.Core.Plugins
 {
     using System;
+    using System.Globalization;
 
     public class PluginParameter : IPluginParameter
     {
@@ -57,7 +58,7 @@
             }
             else
             {
-                Value = Convert.ChangeType(stringValue, Type);
+                Value = Convert.ChangeType(stringValue, Type, CultureInfo.InvariantCulture);
             }
         }
     }

--- a/src/dotless.Test/SpecFixtureBase.cs
+++ b/src/dotless.Test/SpecFixtureBase.cs
@@ -46,7 +46,7 @@
 
         protected void AssertLess(string input, string expected, Parser parser)
         {
-            var output = Evaluate(input, parser).Trim();
+            var output = Evaluate(input, parser).Trim().Replace("\r\n", "\n");
 
             expected = expected.Trim().Replace("\r\n", "\n");
 


### PR DESCRIPTION
- default.build imports system.dll (build crashes without it);
- Parser accepts optimization parameter;
- culture issue fixed in PluginParameter;
- line ending issue fixed in SpecFixtureBase
