### PR TITLE
Duplicate DoesFileExists calls in Importer.ImportLessFile

### DIFF
--- a/src/dotless.Core/Importers/Importer.cs
+++ b/src/dotless.Core/Importers/Importer.cs
@@ -215,15 +215,14 @@ namespace dotless.Core.Importers
             }
             else
             {
-                if (!FileReader.DoesFileExist(lessPath) && !lessPath.EndsWith(".less"))
+                bool fileExists = FileReader.DoesFileExist(lessPath);
+                if (!fileExists && !lessPath.EndsWith(".less"))
                 {
-                    lessPath = lessPath + ".less";
+                    lessPath += ".less";
+                    fileExists = FileReader.DoesFileExist(lessPath);
                 }
 
-                if (!FileReader.DoesFileExist(lessPath))
-                {
-                    return false;
-                }
+                if (!fileExists) return false;
 
                 contents = FileReader.GetFileContents(lessPath);
 

--- a/src/dotless.Test/Specs/ImportFixture.cs
+++ b/src/dotless.Test/Specs/ImportFixture.cs
@@ -216,11 +216,10 @@ body { margin-right: @a; }";
             AssertLess(input, expected, parser);
 
             // Calling the file reader with url's with a protocolis asking for trouble
-            Assert.AreEqual(2, dictionaryReader.DoesFileExistCalls.Count, "We should not ask the file reader if a protocol file exists");
+            Assert.AreEqual(1, dictionaryReader.DoesFileExistCalls.Count, "We should not ask the file reader if a protocol file exists");
             Assert.AreEqual(1, dictionaryReader.GetFileContentsCalls.Count, "We should not ask the file reader if a protocol file exists");
 
             Assert.AreEqual(@"import/other-protocol-test.less", dictionaryReader.DoesFileExistCalls[0], "We should not ask the file reader if a protocol file exists");
-            Assert.AreEqual(@"import/other-protocol-test.less", dictionaryReader.DoesFileExistCalls[1], "We should not ask the file reader if a protocol file exists");
             Assert.AreEqual(@"import/other-protocol-test.less", dictionaryReader.GetFileContentsCalls[0], "We should not ask the file reader if a protocol file exists");
         }
 


### PR DESCRIPTION
Importer.ImportLessFile currently calls FileReader.DoesFileExists twice when a file does not have a .less extension, **even when it exists**.

Having created a custom IFileReader implementation to @import over HTTP, making this call twice is quite costly.
