### PR TITLE
Http Session support added + minor changes/fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ gems/lib/*
 gems/*.gem
 gems/VERSION
 _site/
+src/_UpgradeReport_Files
+src/UpgradeLog.*
 *~
 *.userprefs
 *.pidb

--- a/src/dotless.AspNet/LessCssHttpHandler.cs
+++ b/src/dotless.AspNet/LessCssHttpHandler.cs
@@ -1,25 +1,14 @@
 ﻿namespace dotless.Core
 {
     using System.Web;
-    using configuration;
-    using Microsoft.Practices.ServiceLocation;
-
-    public class LessCssHttpHandler : IHttpHandler
+    using System.Web.SessionState;
+    
+    public class LessCssWithSessionHttpHandler : LessCssHttpHandler, IRequiresSessionState
     {
-        public IServiceLocator Container { get; set; }
-        public DotlessConfiguration Config { get; set; }
+    }
 
-        public LessCssHttpHandler()
-        {
-            Config = new WebConfigConfigurationLoader().GetConfiguration();
-            Container = GetContainerFactory().GetContainer(Config);
-        }
-
-        protected virtual ContainerFactory GetContainerFactory()
-        {
-            return new AspNetContainerFactory();
-        }
-
+    public class LessCssHttpHandler : LessCssHttpHandlerBase, IHttpHandler
+    {
         public void ProcessRequest(HttpContext context)
         {
             try

--- a/src/dotless.AspNet/LessCssHttpHandlerBase.cs
+++ b/src/dotless.AspNet/LessCssHttpHandlerBase.cs
@@ -1,0 +1,39 @@
+namespace dotless.Core
+{
+    using System;
+    using Microsoft.Practices.ServiceLocation;
+    using configuration;
+
+    public abstract class LessCssHttpHandlerBase
+    {
+        private DotlessConfiguration _config;
+        private IServiceLocator _container;
+
+        public DotlessConfiguration Config
+        {
+            get { return _config ?? (_config = new WebConfigConfigurationLoader().GetConfiguration()); }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("value");
+                _config = value;
+            }
+        }
+
+        public IServiceLocator Container
+        {
+            get { return _container ?? (_container = GetContainerFactory().GetContainer(Config)); }
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("value");
+                _container = value;
+            }
+        }
+
+        protected virtual ContainerFactory GetContainerFactory()
+        {
+            return new AspNetContainerFactory();
+        }
+    }
+}

--- a/src/dotless.AspNet/LessCssHttpHandlerFactory.cs
+++ b/src/dotless.AspNet/LessCssHttpHandlerFactory.cs
@@ -1,0 +1,37 @@
+﻿namespace dotless.Core
+{
+    using System;
+    using System.Web;
+    using Abstractions;
+    using configuration;
+    
+    public class LessCssHttpHandlerFactory : LessCssHttpHandlerBase, IHttpHandlerFactory
+    {
+        public IHttpHandler GetHandler(HttpContext context, string requestType, string url, string pathTranslated)
+        {
+            bool sessionRequired;
+            switch (Config.SessionMode)
+            {
+                case DotlessSessionStateMode.Enabled:
+                    sessionRequired = true;
+                    break;
+                case DotlessSessionStateMode.QueryParam:
+                    var http = Container.GetInstance<IHttp>();
+                    var paramValue = http.Context.Request.QueryString[Config.SessionQueryParamName];
+                    sessionRequired = !string.IsNullOrEmpty(paramValue) &&
+                                      paramValue != "0" && !paramValue.Equals("false", StringComparison.OrdinalIgnoreCase);
+                    break;
+                default:
+                    sessionRequired = false;
+                    break;
+            }
+            return sessionRequired
+                       ? new LessCssWithSessionHttpHandler()
+                       : new LessCssHttpHandler();
+        }
+
+        void IHttpHandlerFactory.ReleaseHandler(IHttpHandler handler)
+        {
+        }
+    }
+}

--- a/src/dotless.AspNet/Parameters/QueryStringParameterSource.cs
+++ b/src/dotless.AspNet/Parameters/QueryStringParameterSource.cs
@@ -1,4 +1,7 @@
-﻿namespace dotless.Core.Parameters
+﻿using System;
+using dotless.Core.configuration;
+
+namespace dotless.Core.Parameters
 {
     using System.Collections.Generic;
     using Abstractions;
@@ -20,11 +23,13 @@
             var dictionary = new Dictionary<string, string>();
             var queryString = http.Context.Request.QueryString;
             var allKeys = queryString.AllKeys;
+            var config = new WebConfigConfigurationLoader().GetConfiguration();
+            var sessionParam = config.SessionMode == DotlessSessionStateMode.QueryParam ? config.SessionQueryParamName : null;
             foreach (var key in allKeys)
             {
                 if (key != null)
                 {
-                    if (!_keyWhitelist.IsMatch(key))
+                    if (key.Equals(sessionParam, StringComparison.OrdinalIgnoreCase) || !_keyWhitelist.IsMatch(key))
                         continue;
 
                     string s = queryString[key];

--- a/src/dotless.AspNet/Response/CssResponse.cs
+++ b/src/dotless.AspNet/Response/CssResponse.cs
@@ -41,16 +41,16 @@ namespace dotless.Core.Response
         {
             var context = Http.Context;
 
-            /// load encodings from header
+            // load encodings from header
             QValueList encodings = new QValueList(context.Request.Headers["Accept-Encoding"]);
 
-            /// get the types we can handle, can be accepted and
-            /// in the defined client preference
+            // get the types we can handle, can be accepted and
+            // in the defined client preference
             QValue preferred = encodings.FindPreferred("gzip", "deflate", "identity");
 
-            /// if none of the preferred values were found, but the
-            /// client can accept wildcard encodings, we'll default
-            /// to Gzip.
+            // if none of the preferred values were found, but the
+            // client can accept wildcard encodings, we'll default
+            // to Gzip.
             if (preferred.IsEmpty && encodings.AcceptWildcard && encodings.Find("gzip").IsEmpty)
             {
                 preferred = new QValue("gzip");

--- a/src/dotless.AspNet/dotless.AspNet.csproj
+++ b/src/dotless.AspNet/dotless.AspNet.csproj
@@ -54,6 +54,8 @@
     <Compile Include="Input\AspServerPathResolver.cs" />
     <Compile Include="Input\VirtualFileReader.cs" />
     <Compile Include="LessCssHttpHandler.cs" />
+    <Compile Include="LessCssHttpHandlerBase.cs" />
+    <Compile Include="LessCssHttpHandlerFactory.cs" />
     <Compile Include="Loggers\AspNetTraceLogger.cs" />
     <Compile Include="Loggers\AspResponseLogger.cs" />
     <Compile Include="Parameters\QueryStringParameterSource.cs" />

--- a/src/dotless.Core/Parser/Tree/Rule.cs
+++ b/src/dotless.Core/Parser/Tree/Rule.cs
@@ -22,7 +22,7 @@ namespace dotless.Core.Parser.Tree
         {
             Name = name;
             Value = value;
-            Variable = name != null ? name[0] == '@' : false;
+            Variable = !string.IsNullOrEmpty(name) && name[0] == '@';
             IsSemiColonRequired = true;
             Variadic = variadic;
         }

--- a/src/dotless.Core/configuration/DotlessConfiguration.cs
+++ b/src/dotless.Core/configuration/DotlessConfiguration.cs
@@ -6,8 +6,29 @@ namespace dotless.Core.configuration
     using dotless.Core.Plugins;
     using System.Collections.Generic;
 
+    public enum DotlessSessionStateMode
+    {
+        /// <summary>
+        ///  Session is not used.
+        /// </summary>
+        Disabled,
+
+        /// <summary>
+        ///  Session is loaded for each request to Dotless HTTP handler.
+        /// </summary>
+        Enabled,
+
+        /// <summary>
+        ///  Session is loaded when URL QueryString parameter specified by <seealso cref="DotlessConfiguration.SessionQueryParamName"/> is truthy.
+        /// </summary>
+        QueryParam
+    }
+
     public class DotlessConfiguration
     {
+        public const string DEFAULT_SESSION_QUERY_PARAM_NAME = "sstate";
+        internal static IConfigurationManager _configurationManager;
+
         public static DotlessConfiguration GetDefault()
         {
             return new DotlessConfiguration();
@@ -28,6 +49,8 @@ namespace dotless.Core.configuration
             Debug = false;
             CacheEnabled = true;
             Web = false;
+            SessionMode = DotlessSessionStateMode.Disabled;
+            SessionQueryParamName = DEFAULT_SESSION_QUERY_PARAM_NAME;
             Logger = null;
             LogLevel = LogLevel.Error;
             Optimization = 1;
@@ -44,6 +67,8 @@ namespace dotless.Core.configuration
             Debug = config.Debug;
             CacheEnabled = config.CacheEnabled;
             Web = config.Web;
+            SessionMode = config.SessionMode;
+            SessionQueryParamName = config.SessionQueryParamName;
             Logger = null;
             LogLevel = config.LogLevel;
             Optimization = config.Optimization;
@@ -56,6 +81,19 @@ namespace dotless.Core.configuration
             HandleWebCompression = config.HandleWebCompression;
             DisableParameters = config.DisableParameters;
             DisableVariableRedefines = config.DisableVariableRedefines;
+        }
+
+        public static IConfigurationManager ConfigurationManager
+        {
+            get { return _configurationManager ?? (_configurationManager = new ConfigurationManagerWrapper()); }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+                _configurationManager = value;
+            }
         }
 
         /// <summary>
@@ -114,6 +152,16 @@ namespace dotless.Core.configuration
         ///  Whether this is used in a web context or not
         /// </summary>
         public bool Web { get; set; }
+
+        /// <summary>
+        ///  Specifies the mode the HttpContext.Session is loaded.
+        /// </summary>
+        public DotlessSessionStateMode SessionMode { get; set; }
+
+        /// <summary>
+        ///  Gets or sets the URL QueryString parameter name used in conjunction with <seealso cref="SessionMode"/> set to <seealso cref="DotlessSessionStateMode.QueryParam"/>.
+        /// </summary>
+        public string SessionQueryParamName { get; set; }
 
         /// <summary>
         ///  The ILogger type

--- a/src/dotless.Core/configuration/IConfigurationManager.cs
+++ b/src/dotless.Core/configuration/IConfigurationManager.cs
@@ -1,0 +1,23 @@
+﻿namespace dotless.Core.configuration
+{
+    using System.Configuration;
+
+    /// <summary>
+    ///  Provides access to config sections.
+    /// </summary>
+    public interface IConfigurationManager
+    {
+        T GetSection<T>(string sectionName);
+    }
+
+    /// <summary>
+    ///  Wraps <seealso cref="ConfigurationManager"/> for <seealso cref="IConfigurationManager"/> implementation.
+    /// </summary>
+    public class ConfigurationManagerWrapper : IConfigurationManager
+    {
+        public T GetSection<T>(string sectionName)
+        {
+            return (T) ConfigurationManager.GetSection(sectionName);
+        }
+    }
+}

--- a/src/dotless.Core/configuration/WebConfigConfigurationLoader.cs
+++ b/src/dotless.Core/configuration/WebConfigConfigurationLoader.cs
@@ -1,12 +1,10 @@
 namespace dotless.Core.configuration
 {
-    using System.Configuration;
-
     public class WebConfigConfigurationLoader
     {
         public DotlessConfiguration GetConfiguration()
         {
-            var webconfig = (DotlessConfiguration)ConfigurationManager.GetSection("dotless");
+            var webconfig = DotlessConfiguration.ConfigurationManager.GetSection<DotlessConfiguration>("dotless");
             
             if (webconfig == null)
                 return DotlessConfiguration.GetDefaultWeb();

--- a/src/dotless.Core/configuration/XmlConfigurationInterpreter.cs
+++ b/src/dotless.Core/configuration/XmlConfigurationInterpreter.cs
@@ -1,3 +1,5 @@
+using System.Configuration;
+
 namespace dotless.Core.configuration
 {
     using System;
@@ -53,6 +55,19 @@ namespace dotless.Core.configuration
 
             dotlessConfiguration.Logger = GetTypeValue(section, "logger");
             dotlessConfiguration.Plugins.AddRange(GetPlugins(section));
+
+            var sessionMode = GetStringValue(section, "sessionMode");
+            dotlessConfiguration.SessionMode = string.IsNullOrEmpty(sessionMode)
+                                                   ? DotlessSessionStateMode.Disabled
+                                                   : (DotlessSessionStateMode) Enum.Parse(typeof (DotlessSessionStateMode), sessionMode, true);
+            
+            dotlessConfiguration.SessionQueryParamName = GetStringValue(section, "sessionQueryParamName")
+                                                         ?? DotlessConfiguration.DEFAULT_SESSION_QUERY_PARAM_NAME;
+
+            if (dotlessConfiguration.SessionMode == DotlessSessionStateMode.QueryParam && string.IsNullOrEmpty(dotlessConfiguration.SessionQueryParamName))
+            {
+                throw new ConfigurationErrorsException("The 'sessionQueryParamName' should be not empty when sessionMode is set to 'queryParam'", section);
+            }
 
             return dotlessConfiguration;
         }

--- a/src/dotless.Core/dotless.Core.csproj
+++ b/src/dotless.Core/dotless.Core.csproj
@@ -78,6 +78,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="configuration\IConfigurationManager.cs" />
     <Compile Include="Importers\IImporter.cs" />
     <Compile Include="Loggers\DiagnosticsLogger.cs" />
     <Compile Include="Loggers\NullLogger.cs" />

--- a/src/dotless.Test/Config/XmlConfigurationFixture.cs
+++ b/src/dotless.Test/Config/XmlConfigurationFixture.cs
@@ -1,0 +1,32 @@
+﻿namespace dotless.Test.Config
+{
+    using System.Xml;
+    using NUnit.Framework;
+    using Core.configuration;
+    
+    public class XmlConfigurationFixture
+    {
+        [Test]
+        public void CheckSessionMode()
+        {
+            Assert.That(LoadConfig(@"<dotless sessionMode=""enabled""/>").SessionMode, Is.EqualTo(DotlessSessionStateMode.Enabled));
+            Assert.That(LoadConfig(@"<dotless />").SessionMode, Is.EqualTo(DotlessSessionStateMode.Disabled));
+            Assert.That(LoadConfig(@"<dotless sessionMode=""QueryParam""/>").SessionMode, Is.EqualTo(DotlessSessionStateMode.QueryParam));
+        }
+
+        [Test]
+        [ExpectedException]
+        public void ShouldThrowOnEmptySessionParamName()
+        {
+            LoadConfig(@"<dotless sessionMode=""queryParam"" sessionQueryParamName=""""/>");
+        }
+
+        private DotlessConfiguration LoadConfig(string xml)
+        {
+            var interpreter = new XmlConfigurationInterpreter();
+            var doc = new XmlDocument();
+            doc.LoadXml(xml);
+            return interpreter.Process(doc.DocumentElement);
+        }
+    }
+}

--- a/src/dotless.Test/HttpFixtureBase.cs
+++ b/src/dotless.Test/HttpFixtureBase.cs
@@ -3,6 +3,7 @@ namespace dotless.Test
     using System.Collections.Specialized;
     using System.Web;
     using Core.Abstractions;
+    using Core.configuration;
     using Moq;
     using NUnit.Framework;
     using System.IO;
@@ -16,9 +17,11 @@ namespace dotless.Test
         protected Mock<HttpServerUtilityBase> HttpServer { get; set; }
         protected Mock<HttpCachePolicyBase> HttpCache { get; set; }
         protected Mock<IHttp> Http { get; set; }
+        protected Mock<IConfigurationManager> ConfigManager { get; set; }
         protected NameValueCollection QueryString { get; set; }
         protected NameValueCollection Form { get; set; }
         protected NameValueCollection Headers { get; set; }
+        protected DotlessConfiguration Config { get; set; }
 
         [SetUp]
         public void BaseSetup()
@@ -30,12 +33,17 @@ namespace dotless.Test
             HttpServer = new Mock<HttpServerUtilityBase>();
             HttpCache = new Mock<HttpCachePolicyBase>();
             Http = new Mock<IHttp>();
+            ConfigManager = new Mock<IConfigurationManager>();
 
             QueryString = new NameValueCollection();
             Form = new NameValueCollection();
             Headers = new NameValueCollection();
+            Config = DotlessConfiguration.GetDefaultWeb();
 
             Http.SetupGet(h => h.Context).Returns(HttpContext.Object);
+
+            ConfigManager.Setup(c => c.GetSection<DotlessConfiguration>(It.IsRegex("^dotless$"))).Returns(Config);
+            DotlessConfiguration.ConfigurationManager = ConfigManager.Object;
 
             HttpContext.SetupGet(c => c.Request).Returns(HttpRequest.Object);
             HttpContext.SetupGet(c => c.Response).Returns(HttpResponse.Object);

--- a/src/dotless.Test/Unit/HttpHandlerFixture.cs
+++ b/src/dotless.Test/Unit/HttpHandlerFixture.cs
@@ -1,0 +1,41 @@
+namespace dotless.Test.Unit
+{
+    using NUnit.Framework;
+    using Core;
+    using Core.configuration;
+
+    public class HttpHandlerFixture : HttpFixtureBase
+    {
+        [Test]
+        public void HttpHandlerRequiresSession()
+        {
+            Config.SessionMode = DotlessSessionStateMode.Enabled;
+            CheckHttpHandlerType(true);
+
+            Config.SessionMode = DotlessSessionStateMode.Disabled;
+            CheckHttpHandlerType(false);
+        }
+
+        [Test]
+        [Ignore("Handler factory looks in IHtml.Context.Request.QueryString. Cannot mock IHtml implementor.")]
+        public void SessionParam()
+        {
+            Config.SessionMode = DotlessSessionStateMode.QueryParam;
+            CheckHttpHandlerType(false);
+            QueryString[DotlessConfiguration.DEFAULT_SESSION_QUERY_PARAM_NAME] = "0";
+            CheckHttpHandlerType(false);
+            QueryString[DotlessConfiguration.DEFAULT_SESSION_QUERY_PARAM_NAME] = "false";
+            CheckHttpHandlerType(true);
+            QueryString[DotlessConfiguration.DEFAULT_SESSION_QUERY_PARAM_NAME] = "1";
+            CheckHttpHandlerType(true);
+            QueryString[DotlessConfiguration.DEFAULT_SESSION_QUERY_PARAM_NAME] = "true";
+            CheckHttpHandlerType(true);
+        }
+
+        private static void CheckHttpHandlerType(bool expectedIsSessionAware)
+        {
+            var hdl = new LessCssHttpHandlerFactory().GetHandler(System.Web.HttpContext.Current, "GET", "file.less", @"c:\www\file.less");
+            Assert.That(hdl, expectedIsSessionAware ? Is.TypeOf<LessCssWithSessionHttpHandler>() : Is.TypeOf<LessCssHttpHandler>());
+        }
+    }
+}

--- a/src/dotless.Test/Unit/Parameters/ParameterSourceFixture.cs
+++ b/src/dotless.Test/Unit/Parameters/ParameterSourceFixture.cs
@@ -1,5 +1,6 @@
 namespace dotless.Test.Unit.Parameters
 {
+    using Core.configuration;
     using Core.Parameters;
     using NUnit.Framework;
 
@@ -106,6 +107,23 @@ namespace dotless.Test.Unit.Parameters
             var dictionary = queryStringParameterSource.GetParameters();
 
             Assert.AreEqual(7, dictionary.Count);
+        }
+
+        [Test]
+        public void ShouldSkipSessionParam()
+        {
+            const string paramName = "loadSession";
+
+            Config.SessionMode = DotlessSessionStateMode.QueryParam;
+            Config.SessionQueryParamName = paramName;
+
+            var queryStringParameterSource = new QueryStringParameterSource(Http.Object);
+
+            QueryString[paramName] = "yeah";
+
+            var dictionary = queryStringParameterSource.GetParameters();
+
+            Assert.IsFalse(dictionary.ContainsKey(paramName));
         }
     }
 }

--- a/src/dotless.Test/dotless.Test.csproj
+++ b/src/dotless.Test/dotless.Test.csproj
@@ -83,6 +83,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Config\AspNetConfigurationFixture.cs" />
+    <Compile Include="Config\XmlConfigurationFixture.cs" />
     <Compile Include="Plugins\ColorSpinPluginFixture.cs" />
     <Compile Include="Plugins\PluginFixture.cs" />
     <Compile Include="Plugins\RtlPluginFixture.cs" />
@@ -105,6 +106,7 @@
     <Compile Include="Specs\ScriptFixture.cs" />
     <Compile Include="TestLogger.cs" />
     <Compile Include="TestStylizer.cs" />
+    <Compile Include="Unit\HttpHandlerFixture.cs" />
     <Compile Include="Unit\Tokenizer\TokenizerFixture.cs" />
     <Compile Include="Unit\Engine\CacheDecoratorFixture.cs" />
     <Compile Include="Unit\Engine\CommentBug.cs" />


### PR DESCRIPTION
- Session support for Asp.net handler added:
  
  > LessCssWithSessionHttpHandler inherits LessCssHttpHandler and is marked with IRequiresSessionState;
  > LessCssHttpHandlerFactory, depending on DotlessConfiguration.SessionMode & SessionQueryParamName, constructs LessCssWithSessionHttpHandler or LessCssHttpHandler;
- ConfigurationManager.GetSection wrapped in IConfigurationManager impl.
  
  > First of all, this is for mocking configuration in tests;
  > There's an issue with testing LessCssHttpHandlerFactory: if config.SessionMode==DotlessSessionStateMode.QueryParam, the factory checks QueryString[Config.SessionQueryParamName]. For that it uses Container.GetInstance<IHttp>() — I don't know how to mock it...
- ConfigManager:Mock< IConfigurationManager > and Config:DotlessConfiguration added to HttpFixtureBase;
- Solution/.csproj upgrade related paths added to gitignore;
- Possible ArgumentOutOfRangeException fixed in Rule.
  Http Session support added + minor changes/fixes
