### PR TITLE
Do not compress IE ARGB colors.

### DIFF
--- a/src/dotless.Core/Parser/Parsers.cs
+++ b/src/dotless.Core/Parser/Parsers.cs
@@ -374,13 +374,13 @@ namespace dotless.Core.Parser
         //
         public Color Color(Parser parser)
         {
-            RegexMatchResult rgb;
+            RegexMatchResult hex;
 
             var index = parser.Tokenizer.Location.Index;
 
             if (parser.Tokenizer.CurrentChar == '#' &&
-                (rgb = parser.Tokenizer.Match(@"#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})")))
-                return NodeProvider.Color(rgb[1], parser.Tokenizer.GetNodeLocation(index));
+                (hex = parser.Tokenizer.Match(@"#([a-fA-F0-9]{8}|[a-fA-F0-9]{6}|[a-fA-F0-9]{3})")))
+                return NodeProvider.Color(hex[1], parser.Tokenizer.GetNodeLocation(index));
 
             return null;
         }

--- a/src/dotless.Core/Parser/Tree/Color.cs
+++ b/src/dotless.Core/Parser/Tree/Color.cs
@@ -184,6 +184,8 @@ namespace dotless.Core.Parser.Tree
             }
         }
 
+        private bool isArgb = false;
+
         public readonly double[] RGB;
         public readonly double Alpha;
 
@@ -206,22 +208,32 @@ namespace dotless.Core.Parser.Tree
             Alpha = alpha.Normalize();
         }
 
-        public Color(string rgb)
+        public Color(string hex)
         {
-            if (rgb.Length == 6)
+            Alpha = 1;
+
+            if (hex.Length == 8)
+            {
+                isArgb = true;
+                RGB = Enumerable.Range(1, 3)
+                    .Select(i => hex.Substring(i * 2, 2))
+                    .Select(s => (double) int.Parse(s, NumberStyles.HexNumber))
+                    .ToArray();
+                Alpha = (double) int.Parse(hex.Substring(0, 2), NumberStyles.HexNumber) / 255d;
+            }
+            else if (hex.Length == 6)
             {
                 RGB = Enumerable.Range(0, 3)
-                    .Select(i => rgb.Substring(i*2, 2))
+                    .Select(i => hex.Substring(i*2, 2))
                     .Select(s => (double) int.Parse(s, NumberStyles.HexNumber))
                     .ToArray();
             }
             else
             {
-                RGB = rgb.ToCharArray()
+                RGB = hex.ToCharArray()
                     .Select(c => (double) int.Parse("" + c + c, NumberStyles.HexNumber))
                     .ToArray();
             }
-            Alpha = 1;
         }
 
         public Color(double red, double green, double blue, double alpha)
@@ -281,6 +293,12 @@ namespace dotless.Core.Parser.Tree
             if (Alpha == 0 && rgb[0] == 0 && rgb[1] == 0 && rgb[2] == 0)
             {
                 env.Output.AppendFormat(CultureInfo.InvariantCulture, "transparent");
+                return;
+            }
+
+            if (isArgb)
+            {
+                env.Output.Append(ToArgb());
                 return;
             }
 

--- a/src/dotless.Test/Specs/Compression/ColorsFixture.cs
+++ b/src/dotless.Test/Specs/Compression/ColorsFixture.cs
@@ -10,6 +10,13 @@ namespace dotless.Test.Specs.Compression
             AssertExpression("#fea", "#ffeeaa");
             AssertExpression("blue", "#0000ff");
         }
+
+        [Test]
+        public void Should_not_compress_IE_ARGB()
+        {
+            AssertExpressionUnchanged("#ffaabbcc");
+            AssertExpressionUnchanged("#aabbccdd");
+        }
         
         [Test]
         public void Overflow()


### PR DESCRIPTION
When using IE ARGB colors, we don't want the colors compressed. For example, when using a filter, you'd want to pass the color `#ffffffff`. Currently, dotless would treat this as `white ff` and then IE would fail to render the filter correctly. See [this bootstrap](https://github.com/twitter/bootstrap/issues/4106 issue) for what prompted me to fix this.
