### PR TITLE
Remove try/catch in http handler

### DIFF
--- a/src/dotless.AspNet/LessCssHttpHandler.cs
+++ b/src/dotless.AspNet/LessCssHttpHandler.cs
@@ -11,38 +11,8 @@
     {
         public void ProcessRequest(HttpContext context)
         {
-            try
-            {
                 var handler = Container.GetInstance<HandlerImpl>();
-
-                handler.Execute();
-            }
-            catch (System.IO.FileNotFoundException ex)
-            {
-                context.Response.StatusCode = 404;
-                if (context.Request.IsLocal)
-                {
-                    context.Response.Write("/* File Not Found while parsing: " + ex.Message + " */");
-                }
-                else
-                {
-                    context.Response.Write("/* Error Occurred. Consult log or view on local machine. */");
-                }
-                context.Response.End();
-            }
-            catch (System.IO.IOException ex)
-            {
-                context.Response.StatusCode = 500;
-                if (context.Request.IsLocal)
-                {
-                    context.Response.Write("/* Error in less parsing: " + ex.Message + " */");
-                }
-                else
-                {
-                    context.Response.Write("/* Error Occurred. Consult log or view on local machine. */");
-                }
-                context.Response.End();
-            }
+                handler.Execute();            
         }
 
         public bool IsReusable


### PR DESCRIPTION
The try/catch in the handler hides the detail of the error.  The custom
error settings in the web.config provide sufficient ability to hide
stack traces while allowing developers to perform debugging when needed.
The try/catch also prevents global error handlers from being able to log
the exception.
