### PR TITLE
Fixes for ; not supported in mixin parameter lists #319 #320

### DIFF
--- a/src/dotless.Core/Parser/Parsers.cs
+++ b/src/dotless.Core/Parser/Parsers.cs
@@ -594,7 +594,7 @@ namespace dotless.Core.Parser
         public MixinDefinition MixinDefinition(Parser parser)
         {
             if ((parser.Tokenizer.CurrentChar != '.' && parser.Tokenizer.CurrentChar != '#') ||
-                parser.Tokenizer.Peek(@"[^{]*(;|})"))
+                parser.Tokenizer.Peek(@"[^{]*}"))
                 return null;
 
             var index = parser.Tokenizer.Location.Index;
@@ -654,7 +654,7 @@ namespace dotless.Core.Parser
 
                 GatherAndPullComments(parser);
 
-                if (!parser.Tokenizer.Match(','))
+				if (!(parser.Tokenizer.Match(',') || parser.Tokenizer.Match(';')))
                     break;
 
                 GatherAndPullComments(parser);

--- a/src/dotless.Test/Specs/MixinsArgsFixture.cs
+++ b/src/dotless.Test/Specs/MixinsArgsFixture.cs
@@ -86,6 +86,41 @@ namespace dotless.Test.Specs
             AssertLess(input, expected);
         }
 
+		[Test]
+		public void MixinsArgsTwoArgs_with_semi_colon_separator()
+		{
+			var input =
+				@"
+.mixin (@a: 1px; @b: 50%) {
+  width: @a * 5;
+  height: @b - 1%;
+}
+
+.mixina (@style, @width, @color: black) {
+    border: @width @style @color;
+}
+
+.two-args {
+  color: blue;
+  .mixin(2px, 100%);
+  .mixina(dotted, 2px);
+}
+";
+
+			var expected =
+				@"
+.two-args {
+  color: blue;
+  width: 10px;
+  height: 99%;
+  border: 2px dotted black;
+}
+";
+
+			AssertLess(input, expected);
+		}
+
+
         [Test]
         public void MixinCallError()
         {


### PR DESCRIPTION
All previously passing tests still pass, I added a new test MixinsArgsTwoArgs_with_semi_colon_separator. 
