### PR TITLE
Make Configuration.LessSource an instance rather than a Type

### DIFF
--- a/src/dotless.Core/ContainerFactory.cs
+++ b/src/dotless.Core/ContainerFactory.cs
@@ -88,7 +88,7 @@ namespace dotless.Core
             pandora.Service<ILessEngine>().Implementor<LessEngine>().Parameters("plugins").Set("default-plugins").Lifestyle.Transient();
             pandora.Service<IEnumerable<IPluginConfigurator>>("default-plugins").Instance(configuration.Plugins);
 
-            pandora.Service<IFileReader>().Implementor(configuration.LessSource);
+            pandora.Service<IFileReader>().Instance(configuration.LessSource);
         }
     }
 }

--- a/src/dotless.Core/configuration/DotlessConfiguration.cs
+++ b/src/dotless.Core/configuration/DotlessConfiguration.cs
@@ -44,7 +44,7 @@ namespace dotless.Core.configuration
 
         public DotlessConfiguration()
         {
-            LessSource = typeof (FileReader);
+            LessSource = new FileReader();
             MinifyOutput = false;
             Debug = false;
             CacheEnabled = true;
@@ -153,7 +153,7 @@ namespace dotless.Core.configuration
         /// <summary>
         ///  IFileReader type to use to get imported files
         /// </summary>
-        public Type LessSource { get; set; }
+        public IFileReader LessSource { get; set; }
 
         /// <summary>
         ///  Whether this is used in a web context or not

--- a/src/dotless.Core/configuration/XmlConfigurationInterpreter.cs
+++ b/src/dotless.Core/configuration/XmlConfigurationInterpreter.cs
@@ -1,4 +1,5 @@
 using System.Configuration;
+using dotless.Core.Input;
 
 namespace dotless.Core.configuration
 {
@@ -52,7 +53,7 @@ namespace dotless.Core.configuration
 
             var source = GetTypeValue(section, "source");
             if (source != null)
-                dotlessConfiguration.LessSource = source;
+                dotlessConfiguration.LessSource = (IFileReader)Activator.CreateInstance(source);
 
             dotlessConfiguration.Logger = GetTypeValue(section, "logger");
             dotlessConfiguration.Plugins.AddRange(GetPlugins(section));


### PR DESCRIPTION
I've changed the LessSource in the configuration object to be an instance of IFileProvider rather than Type.
This way it's possible to pass in an IFileReader instance with specific state rather than just a Type that can't contain any state.
