### PR TITLE
changed parse of CSS selector attribute names to allow mixed case

### DIFF
--- a/src/dotless.Core/Parser/Parsers.cs
+++ b/src/dotless.Core/Parser/Parsers.cs
@@ -930,7 +930,7 @@ namespace dotless.Core.Parser
             if (!parser.Tokenizer.Match('['))
                 return null;
 
-            if (key = parser.Tokenizer.Match(@"(\\.|[a-z0-9_-])+") || Quoted(parser))
+            if (key = parser.Tokenizer.Match(@"(\\.|[a-z0-9_-])+", true) || Quoted(parser))
             {
                 Node op;
                 if ((op = parser.Tokenizer.Match(@"[|~*$^]?=")) &&


### PR DESCRIPTION
see issue 334, https://github.com/dotless/dotless/issues/334 ,

if following CSS specified, 

```
img[imgType="sort"]
{ ...
```

then compiler was give error...

   Expected ']' but found 'y' on line XXXX in file '....':

Changing to 

```
img[imgtype="sort"]
```

would get around issue.
