### PR TITLE
Update SelectorFixture test for issue #335 checkin

### DIFF
--- a/src/dotless.Test/Specs/SelectorsFixture.cs
+++ b/src/dotless.Test/Specs/SelectorsFixture.cs
@@ -700,5 +700,16 @@ a:nth-child(2) {
 }";
             AssertLessUnchanged(input);
         }
+        
+		[Test]
+		public void MixedCaseAttributeSelector()
+		{
+			var input = @"
+img[imgType=""sort""] {
+  foo: bar;
+}";
+			AssertLessUnchanged(input);
+		}
+
     }
 }


### PR DESCRIPTION
Unit test for below, fixed in issue #334, #335 where previously a mixed case attribute selector would result in a compile error.
    img[imgType="sort"]
    {
        margin-left:5px;
        padding-left:5px;
    }
