### PR TITLE
Fix major bug with watcher and file being watched having other imports

### DIFF
--- a/src/dotless.Compiler/Program.cs
+++ b/src/dotless.Compiler/Program.cs
@@ -84,13 +84,12 @@ namespace dotless.Compiler
             }
 
             var filenames = Directory.GetFiles(inputDirectoryPath, inputFilePattern);
-            var engine = new EngineFactory(configuration).GetEngine();
 
             using (var watcher = new Watcher() { Watch = configuration.Watch })
             {
                 if (watcher.Watch && HasWildcards(inputFilePattern))
                 {
-                    CompilationFactoryDelegate factoryDelegate = (input) => CreationImpl(engine, input, Path.GetFullPath(outputDirectoryPath));
+                    CompilationFactoryDelegate factoryDelegate = (input) => CreationImpl(new EngineFactory(configuration).GetEngine(), input, Path.GetFullPath(outputDirectoryPath));
                     watcher.SetupDirectoryWatcher(Path.GetFullPath(inputDirectoryPath), inputFilePattern, factoryDelegate);
                 }
 
@@ -105,7 +104,7 @@ namespace dotless.Compiler
 
                     var outputFilePath = Path.GetFullPath(outputFile);
 
-                    CompilationDelegate compilationDelegate = () => CompileImpl(engine, inputFile.FullName, outputFilePath);
+                    CompilationDelegate compilationDelegate = () => CompileImpl(new EngineFactory(configuration).GetEngine(), inputFile.FullName, outputFilePath);
 
                     Console.WriteLine("[Compile]");
 


### PR DESCRIPTION
If a file has other imports such as ...
# import "file1.less";
# import "file2.less"

and the watch is run on this file (e.g. --watch), then the file will compile the first time the compiler is run as --watch, but any changes to the file after that will result in the imports failing.  No imports of the files will be done, they will simply be skipped.

The problem is that a shared "engine" was used for all following compilation delegates instead of a new engine being created for each compile.  

The engine used to not be shared, but was changed in the following checkin...
   https://github.com/dotless/dotless/commit/80b483c7d0ae30e79bad03c624614c5e23850edc#diff-4d66a4cc28d0a6911703f1b28ba48125

At this time, this was probably fine, but when the import was changed to be a default of "import once", then the shared/re-used engine results in this problem.  The engine keeps track of what imports have been done.  On the 2nd and future compiles of the file, the engine detects that the imports have already been done (due to first run of --watch and compile), and therefore skips any other imports.

Creating a new engine for every compile delegate call fixes this issue by having a new fresh uninitialized engine for every compile.
