### PR TITLE
Allow class to import a mixin with the same selector (Issue #136)

### DIFF
--- a/src/dotless.Core/Parser/Infrastructure/Env.cs
+++ b/src/dotless.Core/Parser/Infrastructure/Env.cs
@@ -142,24 +142,27 @@
         }
 
         /// <summary>
-        ///  Finds the first Ruleset matching the selector argument
+        ///  Finds the first Ruleset matching the selector argument that inherits from or is of type TRuleset (pass this as Ruleset if
+        ///  you are trying to find ANY Ruleset that matches the selector)
         /// </summary>
-        public IEnumerable<Closure> FindRulesets(Selector selector)
+        public IEnumerable<Closure> FindRulesets<TRuleset>(Selector selector) where TRuleset : Ruleset
         {
-            return Frames.Select(frame => frame.Find(this, selector, null))
-                .Select(matchedClosuresList => matchedClosuresList.Where(
+            return Frames
+                .Select(frame => frame.Find<TRuleset>(this, selector, null))
+                .Select(
+                    matchedClosuresList => matchedClosuresList.Where(
                             matchedClosure => {
                                 if (!Frames.Any(frame => frame.IsEqualOrClonedFrom(matchedClosure.Ruleset)))
                                     return true;
 
                                 var mixinDef = matchedClosure.Ruleset as MixinDefinition;
                                 if (mixinDef != null)
-                                {
                                     return mixinDef.Condition != null;
-                                }
 
                                 return false;
-                            }))
+                        }
+                    )
+                )
                 .FirstOrDefault(matchedClosuresList => matchedClosuresList.Count() != 0);
         }
 

--- a/src/dotless.Core/Parser/Tree/MixinCall.cs
+++ b/src/dotless.Core/Parser/Tree/MixinCall.cs
@@ -25,8 +25,11 @@ namespace dotless.Core.Parser.Tree
         public override Node Evaluate(Env env)
         {
             var found = false;
-            var closures = env.FindRulesets(Selector);
 
+            // To address bug https://github.com/dotless/dotless/issues/136, where a mixin and ruleset selector may have the same name, we
+            // need to favour matching a MixinDefinition with the required Selector and only fall back to considering other Ruleset types
+            // if no match is found.
+            var closures = env.FindRulesets<MixinDefinition>(Selector) ?? env.FindRulesets<Ruleset>(Selector);
             if(closures == null)
                 throw new ParsingException(Selector.ToCSS(env).Trim() + " is undefined", Location);
 

--- a/src/dotless.Core/Parser/Tree/Ruleset.cs
+++ b/src/dotless.Core/Parser/Tree/Ruleset.cs
@@ -85,17 +85,20 @@ namespace dotless.Core.Parser.Tree
             return Rules.OfType<Ruleset>().ToList();
         }
 
-        public List<Closure> Find(Env env, Selector selector, Ruleset self)
+        public List<Closure> Find<TRuleset>(Env env, Selector selector, Ruleset self) where TRuleset : Ruleset
         {
             self = self ?? this;
             var rules = new List<Closure>();
-            var key = selector.ToCSS(env);
 
+            var key = typeof(TRuleset).ToString() + ":" + selector.ToCSS(env);
             if (_lookups.ContainsKey(key))
                 return _lookups[key];
 
             var validRulesets = Rulesets().Where(rule =>
                 {
+                    if (!typeof(TRuleset).IsAssignableFrom(rule.GetType()))
+                        return false;
+
                     if (rule != self)
                         return true;
 
@@ -116,7 +119,7 @@ namespace dotless.Core.Parser.Tree
                     if (selector.Elements.Count > 1)
                     {
                         var remainingSelectors = new Selector(new NodeList<Element>(selector.Elements.Skip(1)));
-                        var closures = rule.Find(env, remainingSelectors, self);
+                        var closures = rule.Find<Ruleset>(env, remainingSelectors, self);
 
                         foreach (var closure in closures)
                         {

--- a/src/dotless.Test/Specs/MixinsFixture.cs
+++ b/src/dotless.Test/Specs/MixinsFixture.cs
@@ -1544,5 +1544,40 @@ input[type=""submit""].lefticon.icon24-tick.extralarge.fancy:hover {
 
             AssertLess(input, expected);
         }
+
+        [Test]
+        public void MixinUsedInsideSelectorWithInsideSameNameAndInsideSiblingSelector()
+        {
+            // This relates to https://github.com/dotless/dotless/issues/136, the bare minimum reproduce case appears to be a mixin (eg. ".clearfix()"),
+            // followed by a selector (eg. ".panel-body") that imports that mixin follow by a selector whose name matches the mixin's name (".clearfix")
+            // that also imports that mixin. Previously this would lead to a stack overflow when the ".panel-body" selector was evaluated. Note that if
+            // only the ".clearfix()" mixin and the ".clearfix" selector are present then the stack overflow does not occur, it is the ".panel-body"
+            // selector that triggers it.
+            var input =
+                @"
+.clearfix() {
+  color: red;
+}
+
+.panel-body {
+  .clearfix();
+}
+
+.clearfix {
+  .clearfix();
+}
+";
+
+            var expected = @"
+.panel-body {
+  color: red;
+}
+.clearfix {
+  color: red;
+}";
+
+            AssertLess(input, expected);
+        }
+
     }
 }


### PR DESCRIPTION
A class could already import a mxin with the same name but if another
selector within the same scope as that class and the identically-named
mixin tried to import the mixin, a stack overflow would occur. See Issue
#136 for more details and a reproduce case (or see the new unit test in

this changeset).

Although GitHub for Windows showed only the changed lines when I
had to leave a commit message, after sync'ing it would appear that it's
changed all of the line returns and so every line appears as changed.
Using the ?w=1 hack on github.com shows just the changes that I made
but if this is not acceptable then I can try to recreate the changes (though
considering I only changed the affected lines I'm not sure what I could do
better, it's line the Windows client cloned the repo with the Windows-style
line returns.. please let me know if I'm missing something and could
produce a better quality pull request).
