### PR TITLE
Allow IE "\9" hack on rules with evaluated values

### DIFF
--- a/src/dotless.Core/Parser/Parsers.cs
+++ b/src/dotless.Core/Parser/Parsers.cs
@@ -36,6 +36,7 @@ namespace dotless.Core.Parser
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Exceptions;
     using Infrastructure;
     using Infrastructure.Nodes;
@@ -1439,7 +1440,14 @@ namespace dotless.Core.Parser
 
             GatherComments(parser);
 
-            var important = Important(parser);
+            var important = string.Join(
+                " ",
+                new[]
+                {
+                    IESlash9Hack(parser),
+                    Important(parser)
+                }.Where(x => x != "").ToArray()
+            );
 
             if (expressions.Count > 0)
             {
@@ -1461,6 +1469,12 @@ namespace dotless.Core.Parser
             var important = parser.Tokenizer.Match(@"!\s*important");
 
             return important == null ? "" : important.Value;
+        }
+
+        public string IESlash9Hack(Parser parser)
+        {
+            var slashNine = parser.Tokenizer.Match(@"\\9");
+            return slashNine == null ? "" : slashNine.Value;
         }
 
         public Expression Sub(Parser parser)

--- a/src/dotless.Test/Specs/RulesetsFixture.cs
+++ b/src/dotless.Test/Specs/RulesetsFixture.cs
@@ -106,5 +106,34 @@ a:hover {
 
             AssertLess(input, expected);
         }
+
+        [Test]
+        public void IESlash9HackAllowedForEvaluatedValues()
+        {
+            // This has been a problem, where a value must be evaluated a ParsingException would be raised if that value was followed by the
+            // IE-targeting "\9" hack
+            var input = @"li {
+  color: #f00 \9;
+}
+";
+            var expected = @"li {
+  color: red \9;
+}
+";
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void IESlash9HackAllowedForNonEvaluatedValues()
+        {
+            // This has never been a problem but this test is here to illustrate the difference between this parsing and the work required
+            // in IESlash9HackAllowedForEvaluatedValues
+            var input = @"li {
+  color: red \9;
+}
+";
+            var expected = input;
+            AssertLess(input, expected);
+        }
     }
 }


### PR DESCRIPTION
Bootstrap includes rules such as "background-color: #000 \9; // IE8" which dotLess would not parse. It was ok with rules such as "background-color: red \9; // IE8", where it doesn't have to evaluate the value (it just pulls out the string "red" rather than trying to parse "#000"). I've added a unit test for the now-fixed evaulated value version and added one for the already-working non-evaluated value (for regression testing). All of the existing unit tests still pass. This relates to Issue 340.
