### PR TITLE
Enable multi-Element Mixin Selectors

### DIFF
--- a/src/dotless.Core/Parser/Tree/Ruleset.cs
+++ b/src/dotless.Core/Parser/Tree/Ruleset.cs
@@ -116,7 +116,9 @@ namespace dotless.Core.Parser.Tree
             {
                 if (rule.Selectors && rule.Selectors.Any(selector.Match))
                 {
-                    if (selector.Elements.Count > 1)
+                    if ((selector.Elements.Count == 1) || rule.Selectors.Any(s => s.ToCSS(new Env()) == selector.ToCSS(new Env())))
+                        rules.Add(new Closure { Ruleset = rule, Context = new List<Ruleset> { rule } });
+                    else if (selector.Elements.Count > 1)
                     {
                         var remainingSelectors = new Selector(new NodeList<Element>(selector.Elements.Skip(1)));
                         var closures = rule.Find<Ruleset>(env, remainingSelectors, self);
@@ -128,8 +130,6 @@ namespace dotless.Core.Parser.Tree
 
                         rules.AddRange(closures);
                     }
-                    else
-                        rules.Add(new Closure { Ruleset = rule, Context = new List<Ruleset> { rule } });
                 }
             }
             return _lookups[key] = rules;

--- a/src/dotless.Test/Specs/MixinsFixture.cs
+++ b/src/dotless.Test/Specs/MixinsFixture.cs
@@ -1579,5 +1579,31 @@ input[type=""submit""].lefticon.icon24-tick.extralarge.fancy:hover {
             AssertLess(input, expected);
         }
 
+        [Test]
+        public void MultipleElementSelectorMixin()
+        {
+            // Previously, dotLess would require that mixins be selectors with single elements (eg. ".dropdown-menu") since the matching algorithm
+            // would try to match only a single element and then drill down into the selector's rules for any additional elements.. Bootstrap uses
+            // multi-element mixin selectors (eg. ".pull-right > .dropdown"), the drilling down should only be done if the selector does not already
+            // fully match the specified selector.
+            var input = @".pull-right > .dropdown-menu {
+  right: 0;
+}
+
+.navbar-right {
+  .dropdown-menu {
+    .pull-right > .dropdown-menu();
+  }
+}";
+
+            var expected = @".pull-right > .dropdown-menu {
+  right: 0;
+}
+.navbar-right .dropdown-menu {
+  right: 0;
+}";
+            
+            AssertLess(input, expected);
+        }
     }
 }


### PR DESCRIPTION
Previously, dotLess would require that mixins be selectors with single elements (eg. ".dropdown-menu") since the matching algorithm would try to match only a single element and then drill down into the selector's rules for any additional elements. Bootstrap uses multi-element mixin selectors (eg. ".pull-right > .dropdown"), the drilling down should only be done if the selector does not already fully match the specified selector. I've added a unit test to illustrate the fix, the existing unit tests all still pass. The comments on pull request #323 refer to this issue.
