### PR TITLE
Handling of empty declarations...

### DIFF
--- a/src/dotless.Core/Parser/Parsers.cs
+++ b/src/dotless.Core/Parser/Parsers.cs
@@ -763,10 +763,14 @@ namespace dotless.Core.Parser
         // A Rule terminator. Note that we use `Peek()` to check for '}',
         // because the `block` rule will be expecting it, but we still need to make sure
         // it's there, if ';' was ommitted.
-        //
+        // Also note that there might be multiple semicolons between consecutive
+        // declarations, and those semicolons may be separated by whitespace.
         public bool End(Parser parser)
         {
-            return parser.Tokenizer.Match(';') || parser.Tokenizer.Peek('}');
+            // The regular expression searches for a semicolon which may be followed by whitespace and other semicolons.
+            const string SemicolonSearch = @";[;\s]*";
+
+            return parser.Tokenizer.Match(SemicolonSearch) || parser.Tokenizer.Peek('}');
         }
 
         //

--- a/src/dotless.Test/Specs/Compression/WhitespaceFixture.cs
+++ b/src/dotless.Test/Specs/Compression/WhitespaceFixture.cs
@@ -125,5 +125,64 @@ great,
 
             AssertLess(input, expected);
         }
+
+        //
+        // CSS/LESS may contain empty declarations. Instead of throwing an exception,
+        // one can simply ignore them, just like browsers would do.
+        //
+        [Test]
+        public void ConsecutiveSemicolons()
+        {
+            var input = ".semicolon { background:red;; color:blue; }";
+
+            var expected = ".semicolon{background:red;color:blue}";
+
+            AssertLess(input, expected);
+        }
+
+        //
+        // CSS/LESS may contain multiple empty declarations. Instead of throwing an
+        // exception, one can simply ignore them, just like browsers would do.
+        //
+        [Test]
+        public void ConsecutiveMultipleSemicolons()
+        {
+            var input = ".semicolon { background:red;;; color:blue; }";
+
+            var expected = ".semicolon{background:red;color:blue}";
+
+            AssertLess(input, expected);
+        }
+
+        //
+        // CSS/LESS may contain declarations which have only whitespace characters
+        // inside it. Instead of throwing an exception, one can simply ignore them,
+        // just like browsers would do.
+        //
+        [Test]
+        public void ConsecutiveSemicolonsWithWhitespace()
+        {
+            var input = @".semicolon { background:red;   
+  ; color:blue; }";
+
+            var expected = ".semicolon{background:red;color:blue}";
+
+            AssertLess(input, expected);
+        }
+
+        //
+        // CSS/LESS may contain empty declaration at the end of the declaration block.
+        // Instead of throwing an exception, one can simply ignore it, just like browsers
+        // would do.
+        //
+        [Test]
+        public void ConsecutiveSemicolonsBeforeClosingCurlyBracket()
+        {
+            var input = ".semicolon { background:red; color:blue;; }";
+
+            var expected = ".semicolon{background:red;color:blue}";
+
+            AssertLess(input, expected);
+        }
     }
 }


### PR DESCRIPTION
...to avoid throwing an exception when declaration block contains successive semicolons
