### PR TITLE
Enable semicolon for MixinCall and MixinDefinition arguments

### DIFF
--- a/src/dotless.Core/Parser/Parsers.cs
+++ b/src/dotless.Core/Parser/Parsers.cs
@@ -545,7 +545,7 @@ namespace dotless.Core.Parser
 
                     args.Add(new NamedArgument { Name = name, Value = value });
 
-                    if (!parser.Tokenizer.Match(','))
+                    if (!parser.Tokenizer.Match(',') && !parser.Tokenizer.Match(';'))
                         break;
                 }
                 Expect(parser, ')');

--- a/src/dotless.Test/Specs/MixinsArgsFixture.cs
+++ b/src/dotless.Test/Specs/MixinsArgsFixture.cs
@@ -87,6 +87,27 @@ namespace dotless.Test.Specs
         }
 
 		[Test]
+        public void MixinCallWithSemiColonSeparator()
+        {
+            // MixinsArgsTwoArgs_with_semi_colon_separator tests the a MixinDefinition will support semicolon-separated arguments while this
+            // test that a MixinCall will support them
+            var input = @".size(@width, @height) {
+  width: @width;
+  height: @height;
+}
+.container {
+  .size(100px; 50px);
+}";
+
+            var expected = @".container {
+  width: 100px;
+  height: 50px;
+}";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
 		public void MixinsArgsTwoArgs_with_semi_colon_separator()
 		{
 			var input =


### PR DESCRIPTION
This includes Pull Request 323 and I believe addresses Issue 319, Issue 320 and Issue 321 (which are all basically the same). The comments in Pull Request 323 are all also addressed by other recent fixes. The Bootstrap 3 stylesheets now compile without any error! (I haven't yet compared the output from dotLess for Bootstrap with that from less.js but it's looking pretty good in its current state).
