### PR TITLE
Watcher fix when .less file imports a .less.css file - watches .less.less

### DIFF
--- a/src/dotless.Compiler/Program.cs
+++ b/src/dotless.Compiler/Program.cs
@@ -168,7 +168,7 @@ namespace dotless.Compiler
                 var files = new List<string>();
                 files.Add(inputFilePath);
                 foreach (var file in engine.GetImports())
-                    files.Add(Path.Combine(directoryPath, Path.ChangeExtension(file, "less")));
+					files.Add(Path.Combine(directoryPath, Path.GetExtension(file)));
                 engine.ResetImports();
                 return files;
             }


### PR DESCRIPTION
...s.less instead

Assume we have a .less file ...

 #import  "filea"
 #import  "fileb.less"
 #import  "filec.less.css"

If you run the watcher on this file, it watches the following dependent files...

 filea.less
 fileb.less
 filec.less.less

Notice the last file, it is incorrect. If I modify the filec.less.css, the top-level file is not recompiled.  I am assuming the ChangeExtension may have been added to handle import of files without a less extension. e.g. "filea", and then therefore convert to the assumed filename, filea.less.

Seems that the filenames that come back from GetImports are now all correct, e.g. "filea" import is returned as "filea.less". So appears that the change extension is probably no longer required.
