### PR TITLE
Issue #220: Handle missing imported file the same as other errors instea...

### DIFF
--- a/src/dotless.Compiler/Program.cs
+++ b/src/dotless.Compiler/Program.cs
@@ -172,10 +172,13 @@ namespace dotless.Compiler
                 engine.ResetImports();
                 return files;
             }
-            catch (IOException)
+            catch (IOException ex)
             {
+                Console.WriteLine("[FAILED]");
+                Console.WriteLine("Compilation failed: {0}", ex.Message);
+                Console.WriteLine(ex.StackTrace);
                 returnCode = -2;
-                throw;
+                return null;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
...d of crashing the compiler with an unhandled exception.  When the compiler crashes, I can't use it in my build script.
