### PR TITLE
Fix for @import with relative path

### DIFF
--- a/src/dotless.Core/Importers/Importer.cs
+++ b/src/dotless.Core/Importers/Importer.cs
@@ -215,6 +215,9 @@ namespace dotless.Core.Importers
             }
             else
             {
+                if (!IsNonRelativeUrl(lessPath)) {
+                    lessPath = Path.Combine(CurrentDirectory, lessPath);
+                }
                 bool fileExists = FileReader.DoesFileExist(lessPath);
                 if (!fileExists && !lessPath.EndsWith(".less"))
                 {


### PR DESCRIPTION
When you override Importer.CurrentDirectory – it still including files from working path. Here is the fix that allows to import files using specified CurrentDirectory.
