### PR TITLE
Add media scoping to extend syntax

### DIFF
--- a/src/dotless.Core/Parser/Infrastructure/Env.cs
+++ b/src/dotless.Core/Parser/Infrastructure/Env.cs
@@ -45,6 +45,7 @@
             _plugins = new List<IPlugin>();
             _functionTypes = functions ?? new Dictionary<string, Type>();
             _extensions = new List<Extender>();
+            ExtendMediaScope = new Stack<Media>();
 
             if (_functionTypes.Count == 0)
                 AddCoreFunctions();
@@ -102,6 +103,9 @@
                 return _plugins.OfType<IVisitorPlugin>();
             }
         }
+
+        //Keep track of media scoping for extenders
+        public Stack<Media> ExtendMediaScope { get; set; }
 
         /// <summary>
         ///  Returns whether the comment should be silent
@@ -273,11 +277,21 @@
 
         public ExactExtender FindExactExtension(string selection)
         {
+            if (ExtendMediaScope.Any())
+            {
+                return ExtendMediaScope.Select(media => media.FindExactExtension(selection)).FirstOrDefault(result => result != null);
+            }
+
             return _extensions.OfType<ExactExtender>().FirstOrDefault(e => e.BaseSelector.ToString().Trim() == selection);
         }
 
         public PartialExtender[] FindPartialExtensions(string selection)
         {
+            if (ExtendMediaScope.Any())
+            {
+                return ExtendMediaScope.Select(media => media.FindPartialExtensions(selection)).FirstOrDefault(result => result.Any());
+            }
+
             return _extensions.OfType<PartialExtender>().Where(e => selection.Contains(e.BaseSelector.ToString().Trim())).ToArray();
         }
     }

--- a/src/dotless.Core/Parser/Tree/Element.cs
+++ b/src/dotless.Core/Parser/Tree/Element.cs
@@ -59,7 +59,10 @@
             }
             else
             {
-                env.Output.Append(Value);
+                if (Value != "&")
+                {
+                    env.Output.Append(Value);
+                }
             }
             
             env.Output

--- a/src/dotless.Core/Parser/Tree/Ruleset.cs
+++ b/src/dotless.Core/Parser/Tree/Ruleset.cs
@@ -181,7 +181,15 @@ namespace dotless.Core.Parser.Tree
             {
                 foreach (var s in this.Selectors)
                 {
-                    env.AddExtension(s, (Extend)r.Evaluate(env),env);
+                    //If we're in a media block, then extenders can only apply to that media block
+                    if (env.MediaPath.Any())
+                    {
+                        env.MediaPath.Peek().AddExtension(s, (Extend) r.Evaluate(env), env);
+                    }
+                    else //Global extend
+                    {
+                        env.AddExtension(s, (Extend) r.Evaluate(env), env);
+                    }
                 }
                 
                 Rules.Remove(r);
@@ -204,7 +212,7 @@ namespace dotless.Core.Parser.Tree
 
         public override void AppendCSS(Env env)
         {
-            if (!Rules.Any())
+            if (Rules == null || !Rules.Any())
                 return;
 
             ((Ruleset) Evaluate(env)).AppendCSS(env, new Context());

--- a/src/dotless.Core/Parser/Tree/Selector.cs
+++ b/src/dotless.Core/Parser/Tree/Selector.cs
@@ -3,6 +3,7 @@
     using Infrastructure;
     using Infrastructure.Nodes;
     using System.Collections.Generic;
+	using System.Linq;
     using Plugins;
 
     public class Selector : Node
@@ -32,7 +33,14 @@
             {
                 if (element.NodeValue is Extend)
                 {
-                    env.AddExtension(this, (Extend)(((Extend)element.NodeValue).Evaluate(env)),env);
+                    if (env.MediaPath.Any())
+                    {
+                        env.MediaPath.Peek().AddExtension(this, (Extend)(((Extend)element.NodeValue).Evaluate(env)),env);
+                    }
+                    else //Global extend
+                    {
+                        env.AddExtension(this, (Extend)(((Extend)element.NodeValue).Evaluate(env)), env);
+                    }
                 }
                 else
                 {

--- a/src/dotless.Test/Specs/ExtendFixture.cs
+++ b/src/dotless.Test/Specs/ExtendFixture.cs
@@ -208,5 +208,42 @@ pre:hover,
             //var output = Evaluate(input, DefaultParser()).Trim().Replace("\r\n", "\n");
             AssertLess(input, expected);
         }
+
+        [Test]
+        public void ExtendMediaScoping()
+        {
+            var input = @"@media print {
+  .screenClass:extend(.selector) {}
+  .selector {
+    color: black;
+  }
+}
+.selector {
+  color: red;
+}
+@media screen {
+  .selector {
+    color: blue;
+  }
+}";
+
+            var expected = @"@media print {
+  .selector,
+  .screenClass {
+    color: black;
+  }
+}
+.selector {
+  color: red;
+}
+@media screen {
+  .selector {
+    color: blue;
+  }
+}";
+
+            AssertLess(input, expected);
+        }
+
     }
 }


### PR DESCRIPTION
Ensure that the extend syntax, when used in a media block, is only applied to those selectors in the media block.

This addition to the extend feature also gives compatibility with the clearfix rule in bootstrap
