### PR TITLE
Adding support for nested guards, eg & when (condition = true) { ... }

### DIFF
--- a/src/dotless.Core/Parser/Infrastructure/DefaultNodeProvider.cs
+++ b/src/dotless.Core/Parser/Infrastructure/DefaultNodeProvider.cs
@@ -82,6 +82,11 @@ namespace dotless.Core.Parser.Infrastructure
             return new Script(script) { Location = location };
         }
 
+        public GuardedRuleset GuardedRuleset(NodeList<Selector> selectors, NodeList rules, Condition condition, NodeLocation location)
+        {
+            return new GuardedRuleset(selectors, rules, condition) { Location = location };
+        }
+
         public MixinCall MixinCall(NodeList<Element> elements, List<NamedArgument> arguments, bool important, NodeLocation location)
         {
             return new MixinCall(elements, arguments, important) { Location = location };

--- a/src/dotless.Core/Parser/Infrastructure/INodeProvider.cs
+++ b/src/dotless.Core/Parser/Infrastructure/INodeProvider.cs
@@ -26,6 +26,8 @@ namespace dotless.Core.Parser.Infrastructure
         Script Script(string script, NodeLocation location);
         Paren Paren(Node node, NodeLocation location);
 
+        GuardedRuleset GuardedRuleset(NodeList<Selector> selectors, NodeList rules, Condition condition, NodeLocation location);
+
         //mixins
         MixinCall MixinCall(NodeList<Element> elements, List<NamedArgument> arguments, bool important, NodeLocation location);
         MixinDefinition MixinDefinition(string name, NodeList<Rule> parameters, NodeList rules, Condition condition, bool variadic, NodeLocation location);

--- a/src/dotless.Core/Parser/Tree/GuardedRuleset.cs
+++ b/src/dotless.Core/Parser/Tree/GuardedRuleset.cs
@@ -1,0 +1,37 @@
+﻿using dotless.Core.Parser.Infrastructure;
+using dotless.Core.Parser.Infrastructure.Nodes;
+using dotless.Core.Plugins;
+
+namespace dotless.Core.Parser.Tree
+{
+    public class GuardedRuleset : Ruleset
+    {
+        public GuardedRuleset(NodeList<Selector> selectors, NodeList rules, Condition condition)
+            : base(selectors, rules)
+        {
+            this.Condition = condition;
+        }
+
+        public Condition Condition { get; set; }
+
+        public override Node Evaluate(Env env)
+        {
+            var nodeList = new NodeList();
+            if (Condition.Passes(env))
+            {
+                nodeList.Add(Rules);
+            }
+            return nodeList;
+        }
+
+        public override void Accept(IVisitor visitor)
+        {
+            base.Accept(visitor);
+            Condition = VisitAndReplace(Condition, visitor);
+        }
+
+        public override void AppendCSS(Env env)
+        {
+        }
+    }
+}

--- a/src/dotless.Core/Parser/Tree/GuardedRuleset.cs
+++ b/src/dotless.Core/Parser/Tree/GuardedRuleset.cs
@@ -1,4 +1,5 @@
-﻿using dotless.Core.Parser.Infrastructure;
+﻿using System.Linq;
+using dotless.Core.Parser.Infrastructure;
 using dotless.Core.Parser.Infrastructure.Nodes;
 using dotless.Core.Plugins;
 
@@ -16,12 +17,16 @@ namespace dotless.Core.Parser.Tree
 
         public override Node Evaluate(Env env)
         {
-            var nodeList = new NodeList();
             if (Condition.Passes(env))
             {
-                nodeList.Add(Rules);
+                if (Selectors.Any())
+                {
+                    if(!(Selectors.Count == 1 && Selectors[0].Elements.Count == 1 && Selectors[0].Elements[0].Value == "&"))
+                        return base.Evaluate(env);
+                }
+                return new NodeList(Rules);
             }
-            return nodeList;
+            return new NodeList();
         }
 
         public override void Accept(IVisitor visitor)

--- a/src/dotless.Core/Parser/Tree/GuardedRuleset.cs
+++ b/src/dotless.Core/Parser/Tree/GuardedRuleset.cs
@@ -19,12 +19,7 @@ namespace dotless.Core.Parser.Tree
         {
             if (Condition.Passes(env))
             {
-                if (Selectors.Any())
-                {
-                    if(!(Selectors.Count == 1 && Selectors[0].Elements.Count == 1 && Selectors[0].Elements[0].Value == "&"))
-                        return base.Evaluate(env);
-                }
-                return new NodeList(Rules);
+                return EvaluateRulesForFrame(this, env);
             }
             return new NodeList();
         }

--- a/src/dotless.Core/Parser/Tree/MixinDefinition.cs
+++ b/src/dotless.Core/Parser/Tree/MixinDefinition.cs
@@ -121,54 +121,7 @@ namespace dotless.Core.Parser.Tree
             var frames = new[] { this, frame }.Concat(env.Frames).Concat(closureContext).Reverse();
             var context = env.CreateChildEnv(new Stack<Ruleset>(frames));
 
-            var newRules = new NodeList();
-
-            foreach (var rule in Rules)
-            {
-                if (rule is MixinDefinition)
-                {
-                    var mixin = rule as MixinDefinition;
-                    var parameters = Enumerable.Concat(mixin.Params, frame.Rules.Cast<Rule>());
-                    newRules.Add(new MixinDefinition(mixin.Name, new NodeList<Rule>(parameters), mixin.Rules, mixin.Condition, mixin.Variadic));
-                }
-                else if (rule is Import)
-                {
-                    var potentiolNodeList = rule.Evaluate(context);
-                    var nodeList = potentiolNodeList as NodeList;
-                    if (nodeList != null)
-                    {
-                        newRules.AddRange(nodeList);
-                    }
-                    else
-                    {
-                        newRules.Add(potentiolNodeList);
-                    }
-                }
-                else if (rule is Directive || rule is Media)
-                {
-                    newRules.Add(rule.Evaluate(context));
-                }
-                else if (rule is Ruleset)
-                {
-                    var ruleset = (rule as Ruleset);
-
-                    context.Frames.Push(ruleset);
-
-                    newRules.Add(ruleset.Evaluate(context));
-
-                    context.Frames.Pop();
-                }
-                else if (rule is MixinCall)
-                {
-                    newRules.AddRange((NodeList)rule.Evaluate(context));
-                }
-                else
-                {
-                    newRules.Add(rule.Evaluate(context));
-                }
-            }
-
-            return new Ruleset(null, newRules);
+            return EvaluateRulesForFrame(frame, context);
         }
 
         public override MixinMatch MatchArguments(List<NamedArgument> arguments, Env env)

--- a/src/dotless.Core/dotless.Core.csproj
+++ b/src/dotless.Core/dotless.Core.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Parser\ParserLocation.cs" />
     <Compile Include="Parser\Tree\Assignment.cs" />
     <Compile Include="Parser\Tree\Condition.cs" />
+    <Compile Include="Parser\Tree\GuardedRuleset.cs" />
     <Compile Include="Parser\Tree\Media.cs" />
     <Compile Include="Parser\Tree\RepeatEntity.cs" />
     <Compile Include="Parser\Tree\Paren.cs" />

--- a/src/dotless.Test/Specs/GuardedRulesetsFixture.cs
+++ b/src/dotless.Test/Specs/GuardedRulesetsFixture.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace dotless.Test.Specs
+{
+    using NUnit.Framework;
+
+    public class GuardedRulesetsFixture : SpecFixtureBase
+    {
+        [Test]
+        public void GuardedRulesetWithSelector()
+        {
+            var input =
+                @"
+@a: true;
+
+.someClass when (@a = true) {
+  color: white;
+}
+.someClass when (@a = false) {
+  color: black;
+}";
+
+            var expected =
+                @"
+.someClass {
+  color: white;
+}";
+
+            AssertLess(input, expected);
+        }
+        [Test]
+        public void NestedGuardedRulesetWithSelector()
+        {
+            var input =
+                @"
+@a: true;
+
+.someClass {
+  #someId1 when (@a = true) {
+    color: white;
+  }
+  #someId2 when (@a = false) {
+    color: black;
+  }
+  font-weight: bold;
+}";
+
+            var expected =
+                @"
+.someClass {
+  
+  font-weight: bold;
+}
+.someClass #someId1 {
+  color: white;
+}";
+
+            AssertLess(input, expected);
+        }
+    }
+}

--- a/src/dotless.Test/Specs/ImportFixture.cs
+++ b/src/dotless.Test/Specs/ImportFixture.cs
@@ -735,5 +735,55 @@ body {
 
             AssertLess(input, expected, parser);
         }
+
+        [Test]
+        public void ImportProtocolCssInsideMixinsWithNestedGuards()
+        {
+            var input = @"
+.generateImports(@fontFamily) {
+  & when (@fontFamily = Lato) {
+    @import url(https://fonts.googleapis.com/css?family=Lato);
+  }
+  & when (@fontFamily = Cabin) {
+    @import url(https://fonts.googleapis.com/css?family=Cabin);
+  }
+}
+.generateImports(Lato);
+.generateImports(Cabin);
+";
+            
+            var expected = @"
+@import url(https://fonts.googleapis.com/css?family=Lato);
+
+
+@import url(https://fonts.googleapis.com/css?family=Cabin);
+";
+            var parser = GetParser();
+
+            AssertLess(input, expected, parser);
+        }
+
+        [Test]
+        public void ImportProtocolCssInsideMixinsWithGuards()
+        {
+            var input = @"
+.generateImports(@fontFamily) when (@fontFamily = Lato) {
+  @import url(https://fonts.googleapis.com/css?family=Lato);
+}
+.generateImports(@fontFamily) when (@fontFamily = Cabin) {
+  @import url(https://fonts.googleapis.com/css?family=Cabin);
+}
+.generateImports(Lato);
+.generateImports(Cabin);
+";
+
+            var expected = @"
+@import url(https://fonts.googleapis.com/css?family=Lato);
+@import url(https://fonts.googleapis.com/css?family=Cabin);
+";
+            var parser = GetParser();
+
+            AssertLess(input, expected, parser);
+        }
     }
 }

--- a/src/dotless.Test/Specs/MixinGuardsFixture.cs
+++ b/src/dotless.Test/Specs/MixinGuardsFixture.cs
@@ -752,14 +752,18 @@ namespace dotless.Test.Specs
             var expected =
                 @"
 .light1 {
+  
+  margin: 1px;
+}
+.light1 {
   color: white;
+}
+.light2 {
   
   margin: 1px;
 }
 .light2 {
-  
   color: black;
-  margin: 1px;
 }";
 
             AssertLess(input, expected);

--- a/src/dotless.Test/Specs/MixinGuardsFixture.cs
+++ b/src/dotless.Test/Specs/MixinGuardsFixture.cs
@@ -1,8 +1,5 @@
 namespace dotless.Test.Specs
 {
-    using System;
-    using System.Globalization;
-    using System.Threading;
     using NUnit.Framework;
 
     public class MixinGuardsFixture : SpecFixtureBase
@@ -728,6 +725,41 @@ namespace dotless.Test.Specs
 }
 .testClass {
   font-size: 1em;
+}";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void MixinsUsingNestedGuards()
+        {
+            var input =
+                @"
+.light (@a) {
+  & when (lightness(@a) > 50%) {
+    color: white;
+  }
+  & when (lightness(@a) < 50%) {
+    color: black;
+  }
+  margin: 1px;
+}
+
+.light1 { .light(#ddd) }
+.light2 { .light(#444) }
+";
+
+            var expected =
+                @"
+.light1 {
+  color: white;
+  
+  margin: 1px;
+}
+.light2 {
+  
+  color: black;
+  margin: 1px;
 }";
 
             AssertLess(input, expected);

--- a/src/dotless.Test/dotless.Test.csproj
+++ b/src/dotless.Test/dotless.Test.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Specs\Functions\DataUriFixture.cs" />
     <Compile Include="Specs\Functions\GradientImageFixture.cs" />
     <Compile Include="Specs\Functions\PowFixture.cs" />
+    <Compile Include="Specs\GuardedRulesetsFixture.cs" />
     <Compile Include="Specs\LineNumbersFixture.cs" />
     <Compile Include="Specs\MediaFixture.cs" />
     <Compile Include="Specs\Functions\ColorFixture.cs" />


### PR DESCRIPTION
Hi dotless team,
My team are using nested guards in our LESS, and rather than switch to the supported mixin guard syntax, I thought it'd be great to add nested guard support.
I've added a (now passing) test to demonstrate the scenario I want to support. Let me know what you think :)

Cheers,
Mark