### PR TITLE
Adding support for 'unit' function

### DIFF
--- a/src/dotless.Core/Parser/Functions/UnitFunction.cs
+++ b/src/dotless.Core/Parser/Functions/UnitFunction.cs
@@ -1,0 +1,33 @@
+﻿namespace dotless.Core.Parser.Functions
+{
+    using Infrastructure;
+    using Infrastructure.Nodes;
+    using Tree;
+    using Utils;
+
+    public class UnitFunction : Function
+    {
+        protected override Node Evaluate(Env env)
+        {
+            Guard.ExpectMaxArguments(2, Arguments.Count, this, Location);
+            Guard.ExpectNode<Number>(Arguments[0], this, Location);
+
+            var number = Arguments[0] as Number;
+
+            var unit = string.Empty;
+            if (Arguments.Count == 2)
+            {
+                if (Arguments[1] is Keyword)
+                {
+                    unit = ((Keyword)Arguments[1]).Value;
+                }
+                else
+                {
+                    unit = Arguments[1].ToCSS(env);
+                }
+            }
+
+            return new Number(number.Value, unit);
+        }
+    }
+}

--- a/src/dotless.Core/dotless.Core.csproj
+++ b/src/dotless.Core/dotless.Core.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Parser\Functions\ListFunctionBase.cs" />
     <Compile Include="Parser\Functions\ExtractFunction.cs" />
     <Compile Include="Parser\Functions\LengthFunction.cs" />
+    <Compile Include="Parser\Functions\UnitFunction.cs" />
     <Compile Include="Parser\Infrastructure\MimeTypeLookup.cs" />
     <Compile Include="Parser\Functions\NegationFunction.cs" />
     <Compile Include="Parser\Functions\AverageFunction.cs" />

--- a/src/dotless.Test/Specs/Functions/UnitFixture.cs
+++ b/src/dotless.Test/Specs/Functions/UnitFixture.cs
@@ -1,0 +1,28 @@
+namespace dotless.Test.Specs.Functions
+{
+    using NUnit.Framework;
+
+    public class UnitFixture : SpecFixtureBase
+    {
+        [Test]
+        public void Unit()
+        {
+            AssertExpression("5", "unit(5px)");
+            AssertExpression("15", "unit(15em)");
+            AssertExpression("5", "unit(5rem)");
+            AssertExpression("18", "unit(18%)");
+            AssertExpression("5px", "unit(5rem, px)");
+            AssertExpression("5em", "unit(5, em)");
+            AssertExpression("42anything", "unit(42, anything)");
+            AssertExpression("36omg", "unit(36, omg)");
+            AssertExpression("36'omg'", "unit(36, 'omg')");
+            //AssertExpression("5%", "unit(5px, %)"); // FIX '%' is not supported as a parameter
+        }
+
+        [Test]
+        public void ThrowsIfIncorrectType()
+        {
+            AssertExpressionError("Expected number in function 'unit', found at", 0, "unit(at, px)");
+        }
+    }
+}

--- a/src/dotless.Test/Specs/Functions/UnitFixture.cs
+++ b/src/dotless.Test/Specs/Functions/UnitFixture.cs
@@ -24,5 +24,11 @@ namespace dotless.Test.Specs.Functions
         {
             AssertExpressionError("Expected number in function 'unit', found at", 0, "unit(at, px)");
         }
+
+        [Test]
+        public void ThrowIsIncorrectParametersCount()
+        {
+            AssertExpressionError("Expected at most 2 arguments in function 'unit', found 3", 0, "unit(5, 12, px)");
+        }
     }
 }

--- a/src/dotless.Test/dotless.Test.csproj
+++ b/src/dotless.Test/dotless.Test.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Specs\Functions\PowFixture.cs" />
     <Compile Include="Specs\Functions\LengthFixture.cs" />
     <Compile Include="Specs\Functions\ExtractFixture.cs" />
+    <Compile Include="Specs\Functions\UnitFixture.cs" />
     <Compile Include="Specs\LineNumbersFixture.cs" />
     <Compile Include="Specs\MediaFixture.cs" />
     <Compile Include="Specs\Functions\ColorFixture.cs" />


### PR DESCRIPTION
There is one small bug: % is not recognized as a parameter so expression "unit(5px, %)" fail.
It can be fixed by recognized '%' as a keyword using [A-Za-z0-9-%]+ in the Parser.Keyword function.
All tests run but I am not sure about the possible impacts.