### PR TITLE
Changes to the way nested environments are handled (fixes #402)

### DIFF
--- a/src/dotless.Core/Parser/Infrastructure/Env.cs
+++ b/src/dotless.Core/Parser/Infrastructure/Env.cs
@@ -71,6 +71,7 @@ namespace dotless.Core.Parser.Infrastructure
 
         public virtual Env CreateChildEnvWithClosure(Closure closure) {
             var env = CreateChildEnv();
+            env.Rule = Rule;
             env.ClosureEnvironment = CreateChildEnv();
             env.ClosureEnvironment.Frames = new Stack<Ruleset>(closure.Context);
             return env;
@@ -167,7 +168,7 @@ namespace dotless.Core.Parser.Infrastructure
 
             Rule result = null;
             if (Parent != null) {
-                result = Parent.FindVariable(name, null);
+                result = Parent.FindVariable(name, rule);
             }
 
             if (result != null) {
@@ -175,7 +176,7 @@ namespace dotless.Core.Parser.Infrastructure
             }
 
             if (ClosureEnvironment != null) {
-                return ClosureEnvironment.FindVariable(name, null);
+                return ClosureEnvironment.FindVariable(name, rule);
             }
 
             return null;

--- a/src/dotless.Core/Parser/Tree/Extend.cs
+++ b/src/dotless.Core/Parser/Tree/Extend.cs
@@ -24,7 +24,7 @@ namespace dotless.Core.Parser.Tree
             var newExact = new List<Selector>();
             foreach (var e in Exact)
             {
-                var childContext = env.CreateChildEnv(new Stack<Ruleset>(env.Frames.Reverse()));
+                var childContext = env.CreateChildEnv();
                 e.AppendCSS(childContext);
                 newExact.Add(new Selector(new []{new Element(e.Elements.First().Combinator,childContext.Output.ToString().Trim())}));
             }
@@ -32,7 +32,7 @@ namespace dotless.Core.Parser.Tree
             var newPartial = new List<Selector>();
             foreach (var e in Partial)
             {
-                var childContext = env.CreateChildEnv(new Stack<Ruleset>(env.Frames.Reverse()));
+                var childContext = env.CreateChildEnv();
                 e.AppendCSS(childContext);
                 newPartial.Add(new Selector(new[] { new Element(e.Elements.First().Combinator, childContext.Output.ToString().Trim()) }));
             }

--- a/src/dotless.Core/Parser/Tree/MixinCall.cs
+++ b/src/dotless.Core/Parser/Tree/MixinCall.cs
@@ -59,7 +59,8 @@ namespace dotless.Core.Parser.Tree
                     try
                     {
                         var mixin = ruleset as MixinDefinition;
-                        rules.AddRange(mixin.Evaluate(Arguments, env, closure.Context).Rules);
+                        var closureEnvironment = env.CreateChildEnvWithClosure(closure);
+                        rules.AddRange(mixin.Evaluate(Arguments, closureEnvironment).Rules);
                     }
                     catch (ParsingException e)
                     {

--- a/src/dotless.Core/Parser/Tree/MixinDefinition.cs
+++ b/src/dotless.Core/Parser/Tree/MixinDefinition.cs
@@ -102,7 +102,7 @@ namespace dotless.Core.Parser.Tree
               argumentNodes.Add(i < args.Count ? args[i].Value : Params[i].Value);
             }
 
-            var frame = new Ruleset(null, new NodeList());
+            var frame = new Ruleset(new NodeList<Selector>(), new NodeList());
 
             frame.Rules.Insert(0, new Rule("@arguments", new Expression(argumentNodes.Where(a => a != null)).Evaluate(env)));
 
@@ -118,10 +118,8 @@ namespace dotless.Core.Parser.Tree
         {
             var frame = EvaluateParams(env, args);
 
-            env.Frames.Push(this);
-            env.Frames.Push(frame);
-
             var context = env.CreateChildEnv();
+            context.Frames.Push(frame);
 
             var newRules = new NodeList();
 
@@ -165,9 +163,6 @@ namespace dotless.Core.Parser.Tree
                     newRules.Add(rule.Evaluate(context));
                 }
             }
-
-            env.Frames.Pop();
-            env.Frames.Pop();
 
             return new Ruleset(null, newRules);
         }

--- a/src/dotless.Test/Specs/ExtendFixture.cs
+++ b/src/dotless.Test/Specs/ExtendFixture.cs
@@ -268,5 +268,67 @@ pre:hover,
 ";
             AssertLess(input, expected);
         }
+
+        [Test]
+        public void ExtendInLoop() {
+            var input = @"
+.clearfix() {
+  &:before,
+  &:after {
+    content: "" ""; // 1
+    display: table; // 2
+  }
+  &:after {
+    clear: both;
+  }
+}
+
+.make-row() {
+  &:extend(.clearfix all);
+}
+
+.make-rows() {
+  .row(@index) when (@index < 3) {
+    .row@{index} {
+      height: 10 * @index;
+      .make-row();
+    }
+    .row(@index + 1);
+  }
+  .row(1);
+}
+
+.clearfix
+{
+  .clearfix();
+}
+
+.make-rows();
+";
+
+            var expected = @"
+.clearfix:before,
+.clearfix:after,
+.row1:before,
+.row2:before,
+.row1:after,
+.row2:after {
+  content: "" "";
+  display: table;
+}
+.clearfix:after,
+.row1:after,
+.row2:after {
+  clear: both;
+}
+.row1 {
+  height: 10;
+}
+.row2 {
+  height: 20;
+}
+";
+            AssertLess(input, expected);
+        }
     }
 }

--- a/src/dotless.Test/Specs/ExtendFixture.cs
+++ b/src/dotless.Test/Specs/ExtendFixture.cs
@@ -245,5 +245,28 @@ pre:hover,
             AssertLess(input, expected);
         }
 
+        [Test]
+        public void ExtendInMixinDoesNotCauseError() {
+            var input = @"
+.extension {
+  color: red;
+}
+
+.mixin() {
+    .rule {
+        &:extend(.extension all);
+    }
+}
+
+.mixin();
+";
+            var expected = @"
+.extension,
+.rule {
+  color: red;
+}
+";
+            AssertLess(input, expected);
+        }
     }
 }

--- a/src/dotless.Test/Specs/VariablesFixture.cs
+++ b/src/dotless.Test/Specs/VariablesFixture.cs
@@ -373,6 +373,7 @@ namespace dotless.Test.Specs
 
             var expected = @"
 .test {
+  width: 15px;
   width: 20px;
 }
 ";

--- a/src/dotless.Test/Specs/VariablesFixture.cs
+++ b/src/dotless.Test/Specs/VariablesFixture.cs
@@ -373,7 +373,6 @@ namespace dotless.Test.Specs
 
             var expected = @"
 .test {
-  width: 15px;
   width: 20px;
 }
 ";


### PR DESCRIPTION
I advise extreme skepticisim and caution with this one -- after debugging through the triggers for #402 and attempting different fixes, this is what I came up with. Some notes:

At surface, #402 is a null reference where one shouldn't be. Trivially fixed by adding an empty ruleset in lieu of a null, but that won't make the test case pass.

The reason why nothing gets output even after fixing the previous point is that the extendee gets registered within a child environment, but nobody ever searches for extendees in that environment, because the extender is defined in a different environment.

My first fix that actually went somewhere was to register the extendees from child environments in parent envs. That didn't get me very far though, because in this minimal example:

```less
.extension {
  color: red;
}

.mixin() {
    .rule {
        &:extend(.extension all);
    }
}

.mixin();
```

the resulting extendee would expand to ".mixin .mixin .rule .rule" instead of just ".rule" as it should. I came to the conclusion that the reason has to do with the way the child env was being created for the mixin call: the frames from the mixin definition closure were introduced into the child environment's stack. This works in terms of having all the referenced symbols accessible, but it ends up producing the wrong selectors on the stack. 

I tried an approach where I made child environments aware of their parents, made environment lookups recursive and removed the manual construction of child stacks. This got me to a point where only two tests were breaking: they dealt with having a mixin call reference a mixin defined in the same scope. In order to get that to work, I introduced another environment "kind": a child scope with a closure. This kind of environment does lookups up the parent env chain, but also to the closure scope. This way, we can locate the symbols we need, but there are no artificial frames on the stack messing up extendee selector generation.

I have a feeling that having parent-aware environments is the "right" call, but I have some doubts about the way I went about it. For instance, I don't yet understand why I need to push and pop frames in MixinDefinition.cs instead of just having those frames be in the child's stack. And the "closure environment" feels very much like a hack -- but then again, so did the frame shuffling that it replaces.

Final warning: I haven't tested this change set extensively -- instead, I relied on the fact that when I tried different approaches, I usually broke anywhere between 10 to 100 tests before I settled on this one.