### PR TITLE
Fix for #400

### DIFF
--- a/src/dotless.Core/Parser/Infrastructure/Env.cs
+++ b/src/dotless.Core/Parser/Infrastructure/Env.cs
@@ -58,11 +58,37 @@
         {
             return new Env(frames, _functionTypes)
             {
+                Parent = this,
                 Debug = Debug,
                 Compress = Compress,
                 DisableColorCompression = DisableColorCompression,
                 DisableVariableRedefines = DisableVariableRedefines
             };
+        }
+
+        private Env Parent { get; set; }
+
+        /// <summary>
+        ///  Creates a new Env variable for the purposes of scope
+        /// </summary>
+        public virtual Env CreateVariableEvaluationEnv(string variableName, Stack<Ruleset> frames) {
+            var env = CreateChildEnv(frames);
+            env.EvaluatingVariable = variableName;
+            return env;
+        }
+
+        private string EvaluatingVariable { get; set; }
+
+        public bool IsEvaluatingVariable(string variableName) {
+            if (string.Equals(variableName, EvaluatingVariable, StringComparison.InvariantCulture)) {
+                return true;
+            }
+
+            if (Parent != null) {
+                return Parent.IsEvaluatingVariable(variableName);
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/dotless.Core/Parser/Tree/Variable.cs
+++ b/src/dotless.Core/Parser/Tree/Variable.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+
 namespace dotless.Core.Parser.Tree
 {
     using Exceptions;
@@ -22,10 +25,15 @@ namespace dotless.Core.Parser.Tree
                 name = '@' + (v is TextNode ? (v as TextNode).Value : v.ToCSS(env));
             }
 
+            if (env.IsEvaluatingVariable(name)) {
+                throw new ParsingException("Recursive variable definition for " + name, Location);
+            }
+
             var variable = env.FindVariable(name);
 
-            if (variable)
-                return variable.Value.Evaluate(env);
+            if (variable) {
+                return variable.Value.Evaluate(env.CreateVariableEvaluationEnv(name, new Stack<Ruleset>(env.Frames.Reverse())));
+            }
 
             throw new ParsingException("variable " + name + " is undefined", Location);
         }

--- a/src/dotless.Test/Specs/VariablesFixture.cs
+++ b/src/dotless.Test/Specs/VariablesFixture.cs
@@ -542,5 +542,50 @@ namespace dotless.Test.Specs
 ";
             AssertLess(input,expected);
         }
+
+        [Test]
+        public void SimpleRecursiveVariableDefinition()
+        {
+            string input = @"
+@var: 1px;
+@var: @var + 1;
+
+.rule {
+    left: @var;
+}
+";
+
+            string expectedError = @"
+Recursive variable definition for @var on line 2 in file 'test.less':
+  [1]: @var: 1px;
+  [2]: @var: @var + 1;
+       ------^
+  [3]: ";
+
+            AssertError(expectedError, input);
+        }
+
+        [Test]
+        public void IndirectRecursiveVariableDefinition()
+        {
+            string input = @"
+@var: 1px;
+@var2: @var;
+@var: @var2 + 1;
+
+.rule {
+    left: @var;
+}
+";
+
+            string expectedError = @"
+Recursive variable definition for @var on line 2 in file 'test.less':
+  [1]: @var: 1px;
+  [2]: @var2: @var;
+       -------^
+  [3]: @var: @var2 + 1;";
+
+            AssertError(expectedError, input);
+        }
     }
 }


### PR DESCRIPTION
Since this is a problem with recursion, the obvious fix involves recursion, too. Like in the extend-fix branch, I made child environments parent-aware. I then added a private property that labels the environment as a "variable evaluation environment" and added a method for a recursive check to see whether or not we're already evaluating the variable when entering Variable.Evaluate. This way, we get a parser error instead of a stack overflow.

This is not what the issue opener asked for, but it's in line with what less.js does.