### PR TITLE
Fix for #384 and #385 by reimplementing :extend()

### DIFF
--- a/src/dotless.Core/Parser/Infrastructure/Extender.cs
+++ b/src/dotless.Core/Parser/Infrastructure/Extender.cs
@@ -50,26 +50,26 @@ namespace dotless.Core.Parser.Infrastructure
 
         public void AddExtension(Selector selector, Env env)
         {
-            var path = new List<Selector> {selector};
-            path.AddRange(env.Frames.Skip(1).Select(f => f.Selectors.FirstOrDefault()).Where(partialSelector => partialSelector != null));
+            var path = new List<IEnumerable<Selector>> {new [] {selector} };
+            path.AddRange(env.Frames.Skip(1).Select(f => f.Selectors.Where(partialSelector => partialSelector != null)));
 
             path.Reverse();
 
             ExtendedBy.Add(GenerateExtenderSelector(env, path));
         }
 
-        private Selector GenerateExtenderSelector(Env env, IList<Selector> selectorStack) {
+        private Selector GenerateExtenderSelector(Env env, List<IEnumerable<Selector>> selectorStack) {
             var context = GenerateExtenderSelector(new Context(), selectorStack);
             return new Selector(new[] {new Element(null, context.ToCss(env)) });
         }
 
-        private Context GenerateExtenderSelector(Context parentContext, IList<Selector> selectorStack) {
+        private Context GenerateExtenderSelector(Context parentContext, List<IEnumerable<Selector>> selectorStack) {
             if (!selectorStack.Any()) {
                 return parentContext;
             }
 
             var childContext = new Context();
-            childContext.AppendSelectors(parentContext, new[] { selectorStack.First() });
+            childContext.AppendSelectors(parentContext, selectorStack.First());
             return GenerateExtenderSelector(childContext, selectorStack.Skip(1).ToList());
         }
     }

--- a/src/dotless.Core/Parser/Infrastructure/Extender.cs
+++ b/src/dotless.Core/Parser/Infrastructure/Extender.cs
@@ -50,27 +50,27 @@ namespace dotless.Core.Parser.Infrastructure
 
         public void AddExtension(Selector selector, Env env)
         {
-            var path = new List<IEnumerable<Selector>> {new [] {selector} };
-            path.AddRange(env.Frames.Skip(1).Select(f => f.Selectors.Where(partialSelector => partialSelector != null)));
+            var selectorPath = new List<IEnumerable<Selector>> {new [] {selector} };
+            selectorPath.AddRange(env.Frames.Skip(1).Select(f => f.Selectors.Where(partialSelector => partialSelector != null)));
 
-            path.Reverse();
-
-            ExtendedBy.Add(GenerateExtenderSelector(env, path));
+            ExtendedBy.Add(GenerateExtenderSelector(env, selectorPath));
         }
 
-        private Selector GenerateExtenderSelector(Env env, List<IEnumerable<Selector>> selectorStack) {
-            var context = GenerateExtenderSelector(new Context(), selectorStack);
+        private Selector GenerateExtenderSelector(Env env, List<IEnumerable<Selector>> selectorPath) {
+            var context = GenerateExtenderSelector(selectorPath);
             return new Selector(new[] {new Element(null, context.ToCss(env)) });
         }
 
-        private Context GenerateExtenderSelector(Context parentContext, List<IEnumerable<Selector>> selectorStack) {
+        private Context GenerateExtenderSelector(List<IEnumerable<Selector>> selectorStack) {
             if (!selectorStack.Any()) {
-                return parentContext;
+                return null;
             }
+
+            var parentContext = GenerateExtenderSelector(selectorStack.Skip(1).ToList());
 
             var childContext = new Context();
             childContext.AppendSelectors(parentContext, selectorStack.First());
-            return GenerateExtenderSelector(childContext, selectorStack.Skip(1).ToList());
+            return childContext;
         }
     }
 }

--- a/src/dotless.Test/Specs/ExtendFixture.cs
+++ b/src/dotless.Test/Specs/ExtendFixture.cs
@@ -245,5 +245,65 @@ pre:hover,
             AssertLess(input, expected);
         }
 
+        [Test]
+        public void ParentSelector() {
+            var input = @"
+.btn-primary {
+  color: white;
+}
+
+a:link {
+  color: blue;
+}
+
+a:link {
+    &.btn-primary:extend(.btn-primary){}
+}
+";
+
+            var expected = @"
+.btn-primary,
+a:link.btn-primary {
+  color: white;
+}
+a:link {
+  color: blue;
+}
+";
+
+            AssertLess(input, expected);
+        }
+
+        [Test]
+        public void ParentSelectorWithMultipleOuterSelectors() {
+            var input = @"
+.btn-primary {
+  color: white;
+}
+
+a:active,a:visited
+{
+  color: blue;
+}
+
+a:active, a:visited {
+    &.btn-primary:extend(.btn-primary){}
+}
+";
+
+            var expected = @"
+.btn-primary,
+a:active.btn-primary,
+a:visited.btn-primary {
+  color: white;
+}
+a:active,
+a:visited {
+  color: blue;
+}
+";
+
+            AssertLess(input, expected);
+        }
     }
 }


### PR DESCRIPTION
Instead of iterating through the selector list and calling ToCSS on each of them, build a Context that mirrors the one generated during the output pass of dotless. This ensures that whatever logic Context implements for generating selectors is also used for :extend().