### PR TITLE
Support for variable interpolation in @import directives

### DIFF
--- a/src/dotless.Core/Engine/LessEngine.cs
+++ b/src/dotless.Core/Engine/LessEngine.cs
@@ -60,7 +60,7 @@ namespace dotless.Core
                 var tree = Parser.Parse(source, fileName);
 
                 var env = Env ??
-                          new Env
+                          new Env(Parser)
                               {
                                   Compress = Compress,
                                   Debug = Debug,

--- a/src/dotless.Core/Importers/IImporter.cs
+++ b/src/dotless.Core/Importers/IImporter.cs
@@ -35,6 +35,8 @@
         ///  primary url
         /// </summary>
         string AlterUrl(string url, List<string> pathList);
+
+        IDisposable BeginScope(Import parent);
     }
 
     /// <summary>

--- a/src/dotless.Core/Parser/Infrastructure/DefaultNodeProvider.cs
+++ b/src/dotless.Core/Parser/Infrastructure/DefaultNodeProvider.cs
@@ -94,12 +94,12 @@ namespace dotless.Core.Parser.Infrastructure
 
         public Import Import(Url path, IImporter importer, Value features, bool isOnce, NodeLocation location)
         {
-            return new Import(path, importer, features, isOnce) { Location = location };
+            return new Import(path, features, isOnce) { Location = location };
         }
 
         public Import Import(Quoted path, IImporter importer, Value features, bool isOnce, NodeLocation location)
         {
-            return new Import(path, importer, features, isOnce) { Location = location };
+            return new Import(path, features, isOnce) { Location = location };
         }
 
         public Directive Directive(string name, string identifier, NodeList rules, NodeLocation location)

--- a/src/dotless.Core/Parser/Infrastructure/Env.cs
+++ b/src/dotless.Core/Parser/Infrastructure/Env.cs
@@ -29,13 +29,14 @@
         public bool DisableColorCompression { get; set; }
         public bool KeepFirstSpecialComment { get; set; }
         public bool IsFirstSpecialCommentOutput { get; set; }
+        public Parser Parser { get; set; }
 
-        public Env() : this(null, null)
+        public Env(Parser parser) : this(parser, null, null)
         {
         }
 
-        protected Env(Stack<Ruleset> frames, Dictionary<string, Type> functions)
-        {
+        protected Env(Parser parser, Stack<Ruleset> frames, Dictionary<string, Type> functions) {
+            Parser = parser;
             Frames = frames ?? new Stack<Ruleset>();
             Output = new Output(this);
             MediaPath = new Stack<Media>();
@@ -56,7 +57,7 @@
         /// </summary>
         public virtual Env CreateChildEnv(Stack<Ruleset> frames)
         {
-            return new Env(frames, _functionTypes)
+            return new Env(Parser, frames, _functionTypes)
             {
                 Debug = Debug,
                 Compress = Compress,

--- a/src/dotless.Core/Parser/Parsers.cs
+++ b/src/dotless.Core/Parser/Parsers.cs
@@ -1002,7 +1002,7 @@ namespace dotless.Core.Parser
                     (val = Quoted(parser) || parser.Tokenizer.Match(@"[\w-]+")))
                     // Would be nice if this wasn't one block - we could make Attribute node
                     // see CommentsInSelectorAttributes in CommentsFixture.cs
-                    attr = string.Format("{0}{1}{2}", key, op, val.ToCSS(new Env())); 
+                    attr = string.Format("{0}{1}{2}", key, op, val.ToCSS(new Env(null))); 
                 else
                     attr = key.ToString();
             }

--- a/src/dotless.Core/Parser/Tree/Import.cs
+++ b/src/dotless.Core/Parser/Tree/Import.cs
@@ -133,6 +133,8 @@ namespace dotless.Core.Parser.Tree
                 return new NodeList().ReducedFrom<NodeList>(this);
             }
 
+            OriginalPath = OriginalPath.Evaluate(env);
+
             Node features = null;
 
             if (Features)

--- a/src/dotless.Core/Parser/Tree/Root.cs
+++ b/src/dotless.Core/Parser/Tree/Root.cs
@@ -64,7 +64,7 @@ namespace dotless.Core.Parser.Tree
 
             try
             {
-                env = env ?? new Env();
+                env = env ?? new Env(null);
 
                 env.Frames.Push(this);
                 NodeHelper.ExpandNodes<Import>(env, Rules);

--- a/src/dotless.Core/Parser/Tree/Ruleset.cs
+++ b/src/dotless.Core/Parser/Tree/Ruleset.cs
@@ -116,7 +116,7 @@ namespace dotless.Core.Parser.Tree
             {
                 if (rule.Selectors && rule.Selectors.Any(selector.Match))
                 {
-                    if ((selector.Elements.Count == 1) || rule.Selectors.Any(s => s.ToCSS(new Env()) == selector.ToCSS(new Env())))
+                    if ((selector.Elements.Count == 1) || rule.Selectors.Any(s => s.ToCSS(new Env(null)) == selector.ToCSS(new Env(null))))
                         rules.Add(new Closure { Ruleset = rule, Context = new List<Ruleset> { rule } });
                     else if (selector.Elements.Count > 1)
                     {
@@ -361,7 +361,7 @@ namespace dotless.Core.Parser.Tree
         {
             var format = "{0}{{{1}}}";
             return Selectors != null && Selectors.Count > 0
-                       ? string.Format(format, Selectors.Select(s => s.ToCSS(new Env())).JoinStrings(""), Rules.Count)
+                       ? string.Format(format, Selectors.Select(s => s.ToCSS(new Env(null))).JoinStrings(""), Rules.Count)
                        : string.Format(format, "*", Rules.Count);
         }
     }

--- a/src/dotless.Core/Parser/Tree/Selector.cs
+++ b/src/dotless.Core/Parser/Tree/Selector.cs
@@ -78,7 +78,7 @@
 
         public override string ToString()
         {
-            return ToCSS(new Env());
+            return ToCSS(new Env(null));
         }
     }
 }

--- a/src/dotless.Core/Parser/Tree/Value.cs
+++ b/src/dotless.Core/Parser/Tree/Value.cs
@@ -38,7 +38,7 @@
 
         public override string ToString()
         {
-            return ToCSS(new Env()); // only used during debugging.
+            return ToCSS(new Env(null)); // only used during debugging.
         }
 
         public override Node Evaluate(Env env)

--- a/src/dotless.Core/Utils/Guard.cs
+++ b/src/dotless.Core/Utils/Guard.cs
@@ -35,7 +35,7 @@ namespace dotless.Core.Utils
 
             var expected = typeof (TExpected).Name.ToLowerInvariant();
 
-            var message = string.Format("Expected {0} in {1}, found {2}", expected, @in, actual.ToCSS(new Env()));
+            var message = string.Format("Expected {0} in {1}, found {2}", expected, @in, actual.ToCSS(new Env(null)));
 
             throw new ParsingException(message, location);
         }
@@ -48,7 +48,7 @@ namespace dotless.Core.Utils
             var expected1 = typeof(TExpected1).Name.ToLowerInvariant();
             var expected2 = typeof(TExpected2).Name.ToLowerInvariant();
 
-            var message = string.Format("Expected {0} or {1} in {2}, found {3}", expected1, expected2, @in, actual.ToCSS(new Env()));
+            var message = string.Format("Expected {0} or {1} in {2}, found {3}", expected1, expected2, @in, actual.ToCSS(new Env(null)));
 
             throw new ParsingException(message, location);
         }

--- a/src/dotless.Test/CompressedSpecFixtureBase.cs
+++ b/src/dotless.Test/CompressedSpecFixtureBase.cs
@@ -8,7 +8,7 @@ namespace dotless.Test.Specs.Compression
         [SetUp]
         public void Setup()
         {
-            DefaultEnv = () => new Env { Compress = true };
+            DefaultEnv = () => new Env(DefaultParser()) { Compress = true };
         }
     }
 }

--- a/src/dotless.Test/Plugins/ColorSpinPluginFixture.cs
+++ b/src/dotless.Test/Plugins/ColorSpinPluginFixture.cs
@@ -16,7 +16,7 @@ namespace dotless.Test.Plugins
         public void Setup()
         {
             DefaultEnv = () => {
-                Env env = new Env();
+                Env env = new Env(null);
                 env.AddPlugin(new ColorSpinPlugin(60));
                 return env;
             };

--- a/src/dotless.Test/Plugins/RtlPluginFixture.cs
+++ b/src/dotless.Test/Plugins/RtlPluginFixture.cs
@@ -35,7 +35,7 @@
         public void Setup()
         {
             DefaultEnv = () => {
-                Env env = new Env();
+                Env env = new Env(null);
                 env.AddPlugin(new RtlPlugin() { OnlyReversePrefixedRules = OnlyReversePrefixedRules});
                 return env;
             };

--- a/src/dotless.Test/SpecFixtureBase.cs
+++ b/src/dotless.Test/SpecFixtureBase.cs
@@ -31,7 +31,7 @@
             DefaultParser = () => new Parser(Optimisation, DefaultStylizer(), DefaultImporter());
             DefaultEnv = () =>
             {
-                var env = new Env();
+                var env = new Env(DefaultParser());
                 env.AddPlugin(PassThroughAfterPlugin = new PassThroughAfterPlugin());
                 env.AddPlugin(PassThroughBeforePlugin = new PassThroughBeforePlugin());
                 return env;
@@ -232,6 +232,7 @@
         {
             var tree = parser.Parse(input.Trim(), filename);
             var env = DefaultEnv();
+            env.Parser = parser;
             env.Logger = testLogger = new TestLogger(LogLevel.Info);
             return tree.ToCSS(env);
         }

--- a/src/dotless.Test/Specs/Compression/ColorsFixture.cs
+++ b/src/dotless.Test/Specs/Compression/ColorsFixture.cs
@@ -44,14 +44,14 @@ namespace dotless.Test.Specs.Compression
         {
             var oldEnv = DefaultEnv();
 
-            DefaultEnv = () => new Env()
+            DefaultEnv = () => new Env(null)
                 {
                     Compress = true,
                     DisableColorCompression = false
                 };
             AssertExpression("#111", "#111111");
 
-            DefaultEnv = () => new Env()
+            DefaultEnv = () => new Env(null)
             {
                 Compress = true,
                 DisableColorCompression = true

--- a/src/dotless.Test/Specs/Compression/KeepFirstCommentFixture.cs
+++ b/src/dotless.Test/Specs/Compression/KeepFirstCommentFixture.cs
@@ -8,7 +8,7 @@ namespace dotless.Test.Specs.Compression
         [SetUp]
         public void Setup()
         {
-            DefaultEnv = () => new Env { Compress = true, KeepFirstSpecialComment = true };
+            DefaultEnv = () => new Env(null) { Compress = true, KeepFirstSpecialComment = true };
         }
 
         [Test]

--- a/src/dotless.Test/Specs/ImportFixture.cs
+++ b/src/dotless.Test/Specs/ImportFixture.cs
@@ -735,5 +735,23 @@ body {
 
             AssertLess(input, expected, parser);
         }
+
+        [Test]
+        public void VariableInterpolationInQuotedImport()
+        {
+            var input =
+                @"
+@var: ""foo"";
+
+@import ""@{var}/bar.css"";
+";
+
+            var expected =
+                @"
+@import ""foo/bar.css"";
+";
+
+            AssertLess(input, expected);
+        }
     }
 }

--- a/src/dotless.Test/Specs/ImportFixture.cs
+++ b/src/dotless.Test/Specs/ImportFixture.cs
@@ -737,7 +737,7 @@ body {
         }
 
         [Test]
-        public void VariableInterpolationInQuotedImport()
+        public void VariableInterpolationInQuotedCssImport()
         {
             var input =
                 @"
@@ -752,6 +752,25 @@ body {
 ";
 
             AssertLess(input, expected);
+        }
+
+        [Test]
+        public void VariableInterpolationInQuotedLessImport()
+        {
+            var input =
+                @"
+@component: ""color"";
+
+@import ""lib/@{component}.less"";
+";
+
+            var expected =
+                @"
+body {
+  background-color: foo;
+}";
+
+            AssertLess(input, expected, GetParser());
         }
     }
 }


### PR DESCRIPTION
Defer handling of @import's to the evaluation stage.

Keep a reference to the parser in the evaluation `Env` so that when a LESS `Import` is `Evaluate`'d, we can parse it before evaluating. This fixes #353.