### PR TITLE
Fix for #418 (empty style bundle with dotless + System.Web.Optimization.Less)

### DIFF
--- a/src/dotless.AspNet/AspNetContainerFactory.cs
+++ b/src/dotless.AspNet/AspNetContainerFactory.cs
@@ -14,12 +14,19 @@
         protected override void RegisterServices(FluentRegistration pandora, DotlessConfiguration configuration)
         {
             base.RegisterServices(pandora, configuration);
+
+            RegisterParameterSource(pandora, configuration);
+
             RegisterWebServices(pandora, configuration);
+        }
+
+        protected virtual void RegisterParameterSource(FluentRegistration pandora, DotlessConfiguration configuration)
+        {
+            pandora.Service<IParameterSource>().Implementor<NullParameterSource>().Lifestyle.Transient();
         }
 
         private void RegisterWebServices(FluentRegistration pandora, DotlessConfiguration configuration)
         {
-            pandora.Service<IParameterSource>().Implementor<NullParameterSource>().Lifestyle.Transient();
 
             pandora.Service<IHttp>().Implementor<Http>().Lifestyle.Transient();
             pandora.Service<HandlerImpl>().Implementor<HandlerImpl>().Lifestyle.Transient();

--- a/src/dotless.AspNet/AspNetContainerFactory.cs
+++ b/src/dotless.AspNet/AspNetContainerFactory.cs
@@ -19,13 +19,10 @@
 
         private void RegisterWebServices(FluentRegistration pandora, DotlessConfiguration configuration)
         {
+            pandora.Service<IParameterSource>().Implementor<NullParameterSource>().Lifestyle.Transient();
+
             pandora.Service<IHttp>().Implementor<Http>().Lifestyle.Transient();
             pandora.Service<HandlerImpl>().Implementor<HandlerImpl>().Lifestyle.Transient();
-
-            if (!configuration.DisableParameters)
-            {
-                pandora.Service<IParameterSource>().Implementor<QueryStringParameterSource>().Lifestyle.Transient();
-            }
 
             var responseService = configuration.CacheEnabled ?
                 pandora.Service<IResponse>().Implementor<CachedCssResponse>() :

--- a/src/dotless.AspNet/AspNetHttpHandlerContainerFactory.cs
+++ b/src/dotless.AspNet/AspNetHttpHandlerContainerFactory.cs
@@ -1,4 +1,5 @@
-﻿using dotless.Core.Abstractions;
+﻿using System.Net;
+using dotless.Core.Abstractions;
 using dotless.Core.configuration;
 using dotless.Core.Parameters;
 using dotless.Core.Response;
@@ -7,10 +8,8 @@ using Pandora.Fluent;
 namespace dotless.Core {
     public class AspNetHttpHandlerContainerFactory : AspNetContainerFactory
     {
-        protected override void RegisterServices(FluentRegistration pandora, DotlessConfiguration configuration)
+        protected override void RegisterParameterSource(FluentRegistration pandora, DotlessConfiguration configuration)
         {
-            base.RegisterServices(pandora, configuration);
-
             if (!configuration.DisableParameters)
             {
                 pandora.Service<IParameterSource>().Implementor<QueryStringParameterSource>().Lifestyle.Transient();

--- a/src/dotless.AspNet/AspNetHttpHandlerContainerFactory.cs
+++ b/src/dotless.AspNet/AspNetHttpHandlerContainerFactory.cs
@@ -1,0 +1,20 @@
+﻿using dotless.Core.Abstractions;
+using dotless.Core.configuration;
+using dotless.Core.Parameters;
+using dotless.Core.Response;
+using Pandora.Fluent;
+
+namespace dotless.Core {
+    public class AspNetHttpHandlerContainerFactory : AspNetContainerFactory
+    {
+        protected override void RegisterServices(FluentRegistration pandora, DotlessConfiguration configuration)
+        {
+            base.RegisterServices(pandora, configuration);
+
+            if (!configuration.DisableParameters)
+            {
+                pandora.Service<IParameterSource>().Implementor<QueryStringParameterSource>().Lifestyle.Transient();
+            }
+        }
+    }
+}

--- a/src/dotless.AspNet/LessCssHttpHandlerBase.cs
+++ b/src/dotless.AspNet/LessCssHttpHandlerBase.cs
@@ -33,7 +33,7 @@ namespace dotless.Core
 
         protected virtual ContainerFactory GetContainerFactory()
         {
-            return new AspNetContainerFactory();
+            return new AspNetHttpHandlerContainerFactory();
         }
     }
 }

--- a/src/dotless.AspNet/dotless.AspNet.csproj
+++ b/src/dotless.AspNet/dotless.AspNet.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Abstractions\IClock.cs" />
     <Compile Include="Abstractions\IHttp.cs" />
     <Compile Include="AspNetContainerFactory.cs" />
+    <Compile Include="AspNetHttpHandlerContainerFactory.cs" />
     <Compile Include="Cache\HttpCache.cs" />
     <Compile Include="HandlerImpl.cs" />
     <Compile Include="Input\AspRelativePathResolver.cs" />

--- a/src/dotless.Core/Parameters/NullParameterSource.cs
+++ b/src/dotless.Core/Parameters/NullParameterSource.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace dotless.Core.Parameters {
+    public class NullParameterSource : IParameterSource
+    {
+        public IDictionary<string, string> GetParameters()
+        {
+            return new Dictionary<string, string>();
+        }
+    }
+}

--- a/src/dotless.Core/dotless.Core.csproj
+++ b/src/dotless.Core/dotless.Core.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Engine\ParameterDecorator.cs" />
     <Compile Include="Parameters\ConsoleArgumentParameterSource.cs" />
     <Compile Include="Parameters\IParameterSource.cs" />
+    <Compile Include="Parameters\NullParameterSource.cs" />
     <Compile Include="Parser\Functions\ArgbFunction.cs" />
     <Compile Include="Parser\Functions\ColorFunction.cs" />
     <Compile Include="Parser\Functions\DataUriFunction.cs" />

--- a/src/dotless.Test/Config/AspNetConfigurationFixture.cs
+++ b/src/dotless.Test/Config/AspNetConfigurationFixture.cs
@@ -4,6 +4,7 @@ using dotless.Core.Abstractions;
 using dotless.Core.Cache;
 using dotless.Core.Response;
 using dotless.Core.configuration;
+using dotless.Core.Parameters;
 
 namespace dotless.Test.Config
 {
@@ -137,6 +138,18 @@ namespace dotless.Test.Config
             var cache = serviceLocator.GetInstance<ICache>();
 
             Assert.That(cache, Is.TypeOf<HttpCache>());
+        }
+
+        [Test]
+        public void AspNetHttpContainerFactoryHasQueryStringParameterSource()
+        {
+            var config = new DotlessConfiguration { Web = true, CacheEnabled = true };
+
+            var serviceLocator = new AspNetHttpHandlerContainerFactory().GetContainer(config);
+
+            var cache = serviceLocator.GetInstance<IParameterSource>();
+
+            Assert.That(cache, Is.TypeOf<QueryStringParameterSource>());
         }
     }
 }


### PR DESCRIPTION
Repro for the issue:

- Project with S.W.O.L
- Bundle that only has LESS files (couldn't repro with bundles that had CSS files, don't exactly know why)
- Set project startup URL to contain a query string like ?a=1-b that would result in an invalid variable with the ParameterDecorator
- Run site

Result: the bundle is either empty or broken.

Note that the issue only reproduces when the request that initially generates the bundle content has the QS parameters.

Fix is to not use the QueryStringParameterSource with the standalone LESS configuration.