### PR TITLE
Changing luma function to match W3 spec, fixes #437

### DIFF
--- a/src/dotless.Core/Parser/Tree/Color.cs
+++ b/src/dotless.Core/Parser/Tree/Color.cs
@@ -12,6 +12,11 @@ namespace dotless.Core.Parser.Tree
 
     public class Color : Node, IOperable, IComparable
     {
+        private const double DecodingGamma = 2.4;
+        private const double Phi = 2.4;
+        private const double Alpha = .055;
+
+
         private static readonly Dictionary<int, string> Html4ColorsReverse;
 
         private static readonly Dictionary<string, int> Html4Colors =
@@ -283,6 +288,11 @@ namespace dotless.Core.Parser.Tree
             set { RGB[2] = value; }
         }
 
+        private double TransformLinearToSrbg(double linearChannel)
+        {
+            return (linearChannel <= 0.03928) ? linearChannel / 12.92 : Math.Pow(((linearChannel + 0.055) / 1.055), 2.4);
+        }
+
         /// <summary>
         /// Calculates the luma value based on the <a href="http://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef">W3 Standard</a>
         /// </summary>
@@ -293,13 +303,13 @@ namespace dotless.Core.Parser.Tree
         {
             get
             {
-                var red = R / 255;
-                var green = G / 255;
-                var blue = B / 255;
+                var linearR = R / 255; 
+                var linearG = G / 255;
+                var linearB = B / 255;
 
-                red = (red <= 0.03928) ? red / 12.92 : Math.Pow(((red + 0.055) / 1.055), 2.4);
-                green = (green <= 0.03928) ? green / 12.92 : Math.Pow(((green + 0.055) / 1.055), 2.4);
-                blue = (blue <= 0.03928) ? blue / 12.92 : Math.Pow(((blue + 0.055) / 1.055), 2.4);
+                var red = TransformLinearToSrbg(linearR);
+                var green = TransformLinearToSrbg(linearG);
+                var blue = TransformLinearToSrbg(linearB);
                 
                 return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
             }

--- a/src/dotless.Core/Parser/Tree/Color.cs
+++ b/src/dotless.Core/Parser/Tree/Color.cs
@@ -283,6 +283,12 @@ namespace dotless.Core.Parser.Tree
             set { RGB[2] = value; }
         }
 
+        /// <summary>
+        /// Calculates the luma value based on the <a href="http://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef">W3 Standard</a>
+        /// </summary>
+        /// <value>
+        /// The luma value for the current color
+        /// </value>
         public double Luma
         {
             get

--- a/src/dotless.Core/Parser/Tree/Color.cs
+++ b/src/dotless.Core/Parser/Tree/Color.cs
@@ -287,7 +287,15 @@ namespace dotless.Core.Parser.Tree
         {
             get
             {
-                return (0.2126 * R / 255d) + (0.7152 * G / 255d) + (0.0722 * B / 255d);
+                var red = R / 255;
+                var green = G / 255;
+                var blue = B / 255;
+
+                red = (red <= 0.03928) ? red / 12.92 : Math.Pow(((red + 0.055) / 1.055), 2.4);
+                green = (green <= 0.03928) ? green / 12.92 : Math.Pow(((green + 0.055) / 1.055), 2.4);
+                blue = (blue <= 0.03928) ? blue / 12.92 : Math.Pow(((blue + 0.055) / 1.055), 2.4);
+                
+                return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
             }
         }
 

--- a/src/dotless.Test/Specs/Functions/ContrastFixture.cs
+++ b/src/dotless.Test/Specs/Functions/ContrastFixture.cs
@@ -9,7 +9,7 @@
     {
       AssertExpression("white", "contrast(#000000)");
       AssertExpression("white", "contrast(#6D6D6D)");
-      AssertExpression("black", "contrast(#6E6E6E)");
+      AssertExpression("white", "contrast(#6E6E6E)");
       AssertExpression("black", "contrast(#FFFFFF)");
     }
 
@@ -22,10 +22,10 @@
     [Test]
     public void OverrideLightColor()
     {
-      AssertExpression("blue", "contrast(#000000, blue)");
-      AssertExpression("blue", "contrast(#6D6D6D, blue)");
-      AssertExpression("black", "contrast(#6E6E6E, blue)");
-      AssertExpression("black", "contrast(#FFFFFF, blue)");
+      AssertExpression("yellow", "contrast(#000000, yellow)");
+      AssertExpression("yellow", "contrast(#6D6D6D, yellow)");
+      AssertExpression("yellow", "contrast(#6E6E6E, yellow)");
+      AssertExpression("black", "contrast(#FFFFFF, yellow)");
     }
 
     [Test]
@@ -33,7 +33,7 @@
     {
       AssertExpression("white", "contrast(#6D6D6D, white, green)");
       AssertExpression("white", "contrast(#000000, white, green)");
-      AssertExpression("green", "contrast(#6E6E6E, white, green)");
+      AssertExpression("white", "contrast(#6E6E6E, white, green)");
       AssertExpression("green", "contrast(#FFFFFF, white, green)");
     }
 
@@ -41,11 +41,13 @@
     public void OverrideThreshold()
     {
       AssertExpression("white", "contrast(hsl(120, 50%, 0%), white, black, 1%)");
-      AssertExpression("black", "contrast(hsl(120, 50%, 24%), white, black, 25%)");
-      AssertExpression("black", "contrast(hsl(120, 50%, 25%), white, black, 25%)");
-      AssertExpression("black", "contrast(hsl(120, 50%, 74%), white, black, 75%)");
-      AssertExpression("black", "contrast(hsl(120, 50%, 75%), white, black, 75%)");
-      AssertExpression("black", "contrast(hsl(120, 50%, 100%), white, black, 99%)");
+      AssertExpression("white", "contrast(hsl(120, 50%, 24%), white, black, 25%)");
+      AssertExpression("white", "contrast(hsl(120, 50%, 25%), white, black, 25%)");
+      AssertExpression("white", "contrast(#84C447, white, black, 60%)");
+      AssertExpression("black", "contrast(hsl(120, 50%, 74%), white, black, 25%)");
+      AssertExpression("black", "contrast(hsl(120, 50%, 75%), white, black, 25%)");
+      AssertExpression("black", "contrast(hsl(120, 50%, 100%), white, black, 25%)");
+      
     }
   }
 }


### PR DESCRIPTION
I've updated the luma function to match the one from the current version of less (https://github.com/less/less.js/commit/ea1822385a01711b650894cdd923f5871e497d3a)