### PR TITLE
Parent selector in parameterized mixin

### DIFF
--- a/src/dotless.Core/Parser/Tree/Element.cs
+++ b/src/dotless.Core/Parser/Tree/Element.cs
@@ -59,10 +59,7 @@
             }
             else
             {
-                if (Value != "&")
-                {
-                    env.Output.Append(Value);
-                }
+                env.Output.Append(Value);
             }
             
             env.Output

--- a/src/dotless.Test/Specs/SelectorsFixture.cs
+++ b/src/dotless.Test/Specs/SelectorsFixture.cs
@@ -270,6 +270,29 @@ h3 + * {
         }
 
         [Test]
+        public void ParentSelector10()
+        {
+            // https://github.com/dotless/dotless/issues/466
+
+            var input = @"
+.mixin(@suffix) {
+  &-@{suffix} {
+    color: red;
+  }
+}
+.abc {
+  .mixin(xyz);
+}
+";
+            var expected = @"
+.abc-xyz {
+  color: red;
+}
+";
+            AssertLess(input, expected);
+        }
+
+        [Test]
         public void ParentSelectorCombinators()
         {
             // Note: https://github.com/dotless/dotless/issues/171


### PR DESCRIPTION
Fixes #466 with a seemingly trivial change.
I do not understand the fix, so please review. Other tests still pass, so it depends how comfortable you feel about your tests.