### PR TITLE
Support absolute paths in imports when CurrentDirectory isn't null

### DIFF
--- a/src/dotless.Core/Importers/Importer.cs
+++ b/src/dotless.Core/Importers/Importer.cs
@@ -258,7 +258,11 @@ namespace dotless.Core.Importers
             else
             {
                 string fullName = lessPath;
-                if (!string.IsNullOrEmpty(CurrentDirectory)) {
+                if (Path.IsPathRooted(lessPath))
+                {
+                    fullName = lessPath;
+                }
+                else if (!string.IsNullOrEmpty(CurrentDirectory)) {
                     fullName = CurrentDirectory.Replace(@"\", "/").TrimEnd('/') + '/' + lessPath;
                 }
 

--- a/src/dotless.Test/Specs/ImportFixture.cs
+++ b/src/dotless.Test/Specs/ImportFixture.cs
@@ -1742,6 +1742,22 @@ unrecognized @import option 'invalid-option' on line 1 in file 'test.less':
         }
 
         [Test]
+        public void AbsolutePathImportsHonorsCurrentDirectory()
+        {
+            var input = @"
+@import 'c:/absolute/file.less';";
+            var expected = @"
+.windowz .dos {
+  border: none;
+}
+";
+            var parser = GetParser();
+            parser.CurrentDirectory = "import";
+
+            AssertLess(input, expected, parser);
+        }
+
+        [Test]
         public void CssImportsAreHoistedToBeginningOfFile() {
             var input = @"
 @font-face {


### PR DESCRIPTION
Fixes #503 

- Only prepend CurrentDirectory to lessPath in case of relative paths.
- Added a test fixutre for the same