### PR TITLE
Support vmax css unit

### DIFF
--- a/src/dotless.Core/Parser/Parsers.cs
+++ b/src/dotless.Core/Parser/Parsers.cs
@@ -529,7 +529,7 @@ namespace dotless.Core.Parser
 
             var index = parser.Tokenizer.Location.Index;
 
-            var value = parser.Tokenizer.Match(@"([+-]?[0-9]*\.?[0-9]+)(px|%|em|pc|ex|in|deg|s|ms|pt|cm|mm|ch|rem|vw|vh|vmin|vm|grad|rad|fr|gr|Hz|kHz|dpi|dpcm|dppx)?", true);
+            var value = parser.Tokenizer.Match(@"([+-]?[0-9]*\.?[0-9]+)(px|%|em|pc|ex|in|deg|s|ms|pt|cm|mm|ch|rem|vw|vh|vmin|vm|vmax|grad|rad|fr|gr|Hz|kHz|dpi|dpcm|dppx)?", true);
 
             if (value)
                 return NodeProvider.Number(value[1], value[2], parser.Tokenizer.GetNodeLocation(index));

--- a/src/dotless.Test/Specs/Css3Fixture.cs
+++ b/src/dotless.Test/Specs/Css3Fixture.cs
@@ -422,7 +422,7 @@ a ~ p {
         {
             // see http://dev.w3.org/csswg/css3-values/
 
-            List<string> units = new List<string>() { "em", "ex", "ch", "rem", "vw", "vh", "vmin", "vm", "cm", "mm", "%", "in", "pt", "px", "pc", "deg", "grad", "rad", "s", "ms", "fr", "gr", "Hz", "kHz", "dpcm", "dppx" };
+            List<string> units = new List<string>() { "em", "ex", "ch", "rem", "vw", "vh", "vmin", "vm", "vmax", "cm", "mm", "%", "in", "pt", "px", "pc", "deg", "grad", "rad", "s", "ms", "fr", "gr", "Hz", "kHz", "dpcm", "dppx" };
 
             foreach (string unit in units)
             {


### PR DESCRIPTION
Add _vmax_ as a recognized CSS unit to the parser. It currently recognizes _vh_, _vw_, _vmin_, and _vm_. _vm_ was the syntax originally recognized by Internet Explorer, but it has been superseded by _vmax_ in modern browsers.

closes #519 