### PR TITLE
Color hex usage, and Quoted not being cloned properly

### DIFF
--- a/src/dotless.Core/Parser/Tree/Color.cs
+++ b/src/dotless.Core/Parser/Tree/Color.cs
@@ -1,12 +1,12 @@
 namespace dotless.Core.Parser.Tree
 {
+    using Exceptions;
+    using Infrastructure;
+    using Infrastructure.Nodes;
     using System;
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
-    using Exceptions;
-    using Infrastructure;
-    using Infrastructure.Nodes;
     using Utils;
 
     public class Color : Node, IOperable, IComparable
@@ -189,11 +189,13 @@ namespace dotless.Core.Parser.Tree
             return null;
         }
 
-        public static string GetKeyword(int[] rgb) {
+        public static string GetKeyword(int[] rgb)
+        {
             var color = (rgb[0] << 16) + (rgb[1] << 8) + rgb[2];
 
             string keyword;
-            if (Html4ColorsReverse.TryGetValue(color, out keyword)) {
+            if (Html4ColorsReverse.TryGetValue(color, out keyword))
+            {
                 return keyword;
             }
 
@@ -210,7 +212,7 @@ namespace dotless.Core.Parser.Tree
             if (hex.Length == 8)
             {
                 rgb = ParseRgb(hex.Substring(2));
-                alpha = Parse(hex.Substring(0, 2))/255.0;
+                alpha = Parse(hex.Substring(0, 2)) / 255.0;
             }
             else if (hex.Length == 6)
             {
@@ -227,7 +229,7 @@ namespace dotless.Core.Parser.Tree
         private static double[] ParseRgb(string hex)
         {
             return Enumerable.Range(0, 3)
-                .Select(i => hex.Substring(i*2, 2))
+                .Select(i => hex.Substring(i * 2, 2))
                 .Select(Parse)
                 .ToArray();
         }
@@ -239,7 +241,8 @@ namespace dotless.Core.Parser.Tree
 
         private readonly string _text;
 
-        public Color(int color) {
+        public Color(int color)
+        {
             RGB = new double[3];
 
             B = color & 0xff;
@@ -250,7 +253,8 @@ namespace dotless.Core.Parser.Tree
             Alpha = 1;
         }
 
-        public Color(string hex) {
+        public Color(string hex)
+        {
             hex = hex.TrimStart('#');
             double[] rgb;
             var alpha = 1.0;
@@ -259,7 +263,7 @@ namespace dotless.Core.Parser.Tree
             if (hex.Length == 8)
             {
                 rgb = ParseRgb(hex.Substring(2));
-                alpha = Parse(hex.Substring(0, 2))/255.0;
+                alpha = Parse(hex.Substring(0, 2)) / 255.0;
             }
             else if (hex.Length == 6)
             {
@@ -278,26 +282,31 @@ namespace dotless.Core.Parser.Tree
             _text = text;
         }
 
-        public Color(IEnumerable<Number> rgb, Number alpha) {
+        public Color(IEnumerable<Number> rgb, Number alpha)
+        {
             RGB = rgb.Select(d => d.Normalize()).ToArray();
 
             Alpha = alpha.Normalize();
         }
 
-        public Color(double r, double g, double b) : this(r, g, b, 1) {
-            
+        public Color(double r, double g, double b) : this(r, g, b, 1)
+        {
+
         }
 
-        public Color(double r, double g, double b, double alpha) : this(new[] {r, g, b}, alpha) {
-            
+        public Color(double r, double g, double b, double alpha) : this(new[] { r, g, b }, alpha)
+        {
+
         }
 
-        public Color(double[] rgb) : this(rgb, 1) {
-            
+        public Color(double[] rgb) : this(rgb, 1)
+        {
+
         }
 
-        public Color(double[] rgb, double alpha) : this(rgb, alpha, null) {
-            
+        public Color(double[] rgb, double alpha) : this(rgb, alpha, null)
+        {
+
         }
 
         public Color(double[] rgb, double alpha, string text)
@@ -308,12 +317,12 @@ namespace dotless.Core.Parser.Tree
         }
 
         public Color(double red, double green, double blue, double alpha = 1.0, string text = null)
-            : this(new[] {red, green, blue}, alpha, text)
+            : this(new[] { red, green, blue }, alpha, text)
         {
         }
 
         // TODO: A RGB color should really be represented by int[], or better: a compressed int.
-        public readonly double[] RGB;
+        public readonly double[] RGB = new double[3];
         public readonly double Alpha;
 
         public double R
@@ -357,19 +366,20 @@ namespace dotless.Core.Parser.Tree
         {
             get
             {
-                var linearR = R / 255; 
+                var linearR = R / 255;
                 var linearG = G / 255;
                 var linearB = B / 255;
 
                 var red = TransformLinearToSrbg(linearR);
                 var green = TransformLinearToSrbg(linearG);
                 var blue = TransformLinearToSrbg(linearB);
-                
+
                 return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
             }
         }
 
-        protected override Node CloneCore() {
+        protected override Node CloneCore()
+        {
             return new Color(RGB.ToArray(), Alpha);
         }
 
@@ -395,7 +405,7 @@ namespace dotless.Core.Parser.Tree
 
         private List<int> ConvertToInt(IEnumerable<double> rgb)
         {
-            return rgb.Select(d => (int) Math.Round(d, MidpointRounding.AwayFromZero)).ToList();
+            return rgb.Select(d => (int)Math.Round(d, MidpointRounding.AwayFromZero)).ToList();
         }
 
         private string GetHexString(IEnumerable<int> rgb)
@@ -434,7 +444,7 @@ namespace dotless.Core.Parser.Tree
         /// <returns></returns>
         public string ToArgb()
         {
-            var values = new[] {Alpha*255}.Concat(RGB);
+            var values = new[] { Alpha * 255 }.Concat(RGB);
             var argb = ConvertToInt(values);
             return GetHexString(argb);
         }
@@ -461,7 +471,7 @@ namespace dotless.Core.Parser.Tree
             if (color == null)
                 throw new ArgumentNullException("color");
 
-            return System.Drawing.Color.FromArgb((int) Math.Round(color.Alpha * 255d), (int) color.R, (int) color.G, (int) color.B);
+            return System.Drawing.Color.FromArgb((int)Math.Round(color.Alpha * 255d), (int)color.R, (int)color.G, (int)color.B);
         }
     }
 }

--- a/src/dotless.Core/Parser/Tree/Color.cs
+++ b/src/dotless.Core/Parser/Tree/Color.cs
@@ -1,12 +1,12 @@
 namespace dotless.Core.Parser.Tree
 {
-    using Exceptions;
-    using Infrastructure;
-    using Infrastructure.Nodes;
     using System;
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using Exceptions;
+    using Infrastructure;
+    using Infrastructure.Nodes;
     using Utils;
 
     public class Color : Node, IOperable, IComparable
@@ -189,13 +189,11 @@ namespace dotless.Core.Parser.Tree
             return null;
         }
 
-        public static string GetKeyword(int[] rgb)
-        {
+        public static string GetKeyword(int[] rgb) {
             var color = (rgb[0] << 16) + (rgb[1] << 8) + rgb[2];
 
             string keyword;
-            if (Html4ColorsReverse.TryGetValue(color, out keyword))
-            {
+            if (Html4ColorsReverse.TryGetValue(color, out keyword)) {
                 return keyword;
             }
 
@@ -212,7 +210,7 @@ namespace dotless.Core.Parser.Tree
             if (hex.Length == 8)
             {
                 rgb = ParseRgb(hex.Substring(2));
-                alpha = Parse(hex.Substring(0, 2)) / 255.0;
+                alpha = Parse(hex.Substring(0, 2))/255.0;
             }
             else if (hex.Length == 6)
             {
@@ -229,7 +227,7 @@ namespace dotless.Core.Parser.Tree
         private static double[] ParseRgb(string hex)
         {
             return Enumerable.Range(0, 3)
-                .Select(i => hex.Substring(i * 2, 2))
+                .Select(i => hex.Substring(i*2, 2))
                 .Select(Parse)
                 .ToArray();
         }
@@ -241,8 +239,7 @@ namespace dotless.Core.Parser.Tree
 
         private readonly string _text;
 
-        public Color(int color)
-        {
+        public Color(int color) {
             RGB = new double[3];
 
             B = color & 0xff;
@@ -253,8 +250,7 @@ namespace dotless.Core.Parser.Tree
             Alpha = 1;
         }
 
-        public Color(string hex)
-        {
+        public Color(string hex) {
             hex = hex.TrimStart('#');
             double[] rgb;
             var alpha = 1.0;
@@ -263,7 +259,7 @@ namespace dotless.Core.Parser.Tree
             if (hex.Length == 8)
             {
                 rgb = ParseRgb(hex.Substring(2));
-                alpha = Parse(hex.Substring(0, 2)) / 255.0;
+                alpha = Parse(hex.Substring(0, 2))/255.0;
             }
             else if (hex.Length == 6)
             {
@@ -282,31 +278,26 @@ namespace dotless.Core.Parser.Tree
             _text = text;
         }
 
-        public Color(IEnumerable<Number> rgb, Number alpha)
-        {
+        public Color(IEnumerable<Number> rgb, Number alpha) {
             RGB = rgb.Select(d => d.Normalize()).ToArray();
 
             Alpha = alpha.Normalize();
         }
 
-        public Color(double r, double g, double b) : this(r, g, b, 1)
-        {
-
+        public Color(double r, double g, double b) : this(r, g, b, 1) {
+            
         }
 
-        public Color(double r, double g, double b, double alpha) : this(new[] { r, g, b }, alpha)
-        {
-
+        public Color(double r, double g, double b, double alpha) : this(new[] {r, g, b}, alpha) {
+            
         }
 
-        public Color(double[] rgb) : this(rgb, 1)
-        {
-
+        public Color(double[] rgb) : this(rgb, 1) {
+            
         }
 
-        public Color(double[] rgb, double alpha) : this(rgb, alpha, null)
-        {
-
+        public Color(double[] rgb, double alpha) : this(rgb, alpha, null) {
+            
         }
 
         public Color(double[] rgb, double alpha, string text)
@@ -317,7 +308,7 @@ namespace dotless.Core.Parser.Tree
         }
 
         public Color(double red, double green, double blue, double alpha = 1.0, string text = null)
-            : this(new[] { red, green, blue }, alpha, text)
+            : this(new[] {red, green, blue}, alpha, text)
         {
         }
 
@@ -366,20 +357,19 @@ namespace dotless.Core.Parser.Tree
         {
             get
             {
-                var linearR = R / 255;
+                var linearR = R / 255; 
                 var linearG = G / 255;
                 var linearB = B / 255;
 
                 var red = TransformLinearToSrbg(linearR);
                 var green = TransformLinearToSrbg(linearG);
                 var blue = TransformLinearToSrbg(linearB);
-
+                
                 return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
             }
         }
 
-        protected override Node CloneCore()
-        {
+        protected override Node CloneCore() {
             return new Color(RGB.ToArray(), Alpha);
         }
 
@@ -405,7 +395,7 @@ namespace dotless.Core.Parser.Tree
 
         private List<int> ConvertToInt(IEnumerable<double> rgb)
         {
-            return rgb.Select(d => (int)Math.Round(d, MidpointRounding.AwayFromZero)).ToList();
+            return rgb.Select(d => (int) Math.Round(d, MidpointRounding.AwayFromZero)).ToList();
         }
 
         private string GetHexString(IEnumerable<int> rgb)
@@ -444,7 +434,7 @@ namespace dotless.Core.Parser.Tree
         /// <returns></returns>
         public string ToArgb()
         {
-            var values = new[] { Alpha * 255 }.Concat(RGB);
+            var values = new[] {Alpha*255}.Concat(RGB);
             var argb = ConvertToInt(values);
             return GetHexString(argb);
         }
@@ -471,7 +461,7 @@ namespace dotless.Core.Parser.Tree
             if (color == null)
                 throw new ArgumentNullException("color");
 
-            return System.Drawing.Color.FromArgb((int)Math.Round(color.Alpha * 255d), (int)color.R, (int)color.G, (int)color.B);
+            return System.Drawing.Color.FromArgb((int) Math.Round(color.Alpha * 255d), (int) color.R, (int) color.G, (int) color.B);
         }
     }
 }

--- a/src/dotless.Core/Parser/Tree/Quoted.cs
+++ b/src/dotless.Core/Parser/Tree/Quoted.cs
@@ -1,9 +1,9 @@
 ﻿namespace dotless.Core.Parser.Tree
 {
-    using System.Text.RegularExpressions;
     using Infrastructure;
     using Infrastructure.Nodes;
-using System.Text;
+    using System.Text;
+    using System.Text.RegularExpressions;
 
     public class Quoted : TextNode
     {
@@ -43,6 +43,11 @@ using System.Text;
                 .Append(RenderString());
         }
 
+        protected override Node CloneCore()
+        {
+            return new Quoted(Value, Quote, Escaped);
+        }
+
         public StringBuilder RenderString()
         {
             if (Escaped)
@@ -66,8 +71,8 @@ using System.Text;
             var value = Regex.Replace(Value, @"@\{([\w-]+)\}",
                           m =>
                           {
-                              var v = new Variable('@' + m.Groups[1].Value) 
-                                    { Location = new NodeLocation(Location.Index + m.Index, Location.Source, Location.FileName) }
+                              var v = new Variable('@' + m.Groups[1].Value)
+                              { Location = new NodeLocation(Location.Index + m.Index, Location.Source, Location.FileName) }
                                     .Evaluate(env);
                               return v is TextNode ? (v as TextNode).Value : v.ToCSS(env);
                           });

--- a/src/dotless.Core/Parser/Tree/Quoted.cs
+++ b/src/dotless.Core/Parser/Tree/Quoted.cs
@@ -1,9 +1,9 @@
 ﻿namespace dotless.Core.Parser.Tree
 {
+    using System.Text.RegularExpressions;
     using Infrastructure;
     using Infrastructure.Nodes;
-    using System.Text;
-    using System.Text.RegularExpressions;
+using System.Text;
 
     public class Quoted : TextNode
     {
@@ -37,15 +37,15 @@
             Quote = null;
         }
 
+        protected override Node CloneCore()
+        {
+            return new Quoted(Value, Quote, Escaped);
+        }
+
         public override void AppendCSS(Env env)
         {
             env.Output
                 .Append(RenderString());
-        }
-
-        protected override Node CloneCore()
-        {
-            return new Quoted(Value, Quote, Escaped);
         }
 
         public StringBuilder RenderString()
@@ -71,8 +71,8 @@
             var value = Regex.Replace(Value, @"@\{([\w-]+)\}",
                           m =>
                           {
-                              var v = new Variable('@' + m.Groups[1].Value)
-                              { Location = new NodeLocation(Location.Index + m.Index, Location.Source, Location.FileName) }
+                              var v = new Variable('@' + m.Groups[1].Value) 
+                                    { Location = new NodeLocation(Location.Index + m.Index, Location.Source, Location.FileName) }
                                     .Evaluate(env);
                               return v is TextNode ? (v as TextNode).Value : v.ToCSS(env);
                           });

--- a/tests/dotless.Core.Test/Specs/MixinsFixture.cs
+++ b/tests/dotless.Core.Test/Specs/MixinsFixture.cs
@@ -1968,5 +1968,33 @@ fieldset[disabled] .test {
 
             AssertLess(input, expected);
         }
+
+        [Test]
+        public void MixinWithEmptyContent_WithoutParantheses_CorrectlyCopiesContent()
+        {
+            var input = @"
+.mixinWithContent {
+  content: '';
+}
+
+.useMixinWithoutParantheses {
+  .mixinWithContent;
+}
+
+.useMixinWithParantheses {
+  .mixinWithContent();
+}";
+            var expected = @"
+.mixinWithContent {
+  content: '';
+}
+.useMixinWithoutParantheses {
+  content: '';
+}
+.useMixinWithParantheses {
+  content: '';
+}";
+            AssertLess (input, expected);
+        }
     }
 }

--- a/tests/dotless.Core.Test/Unit/Parser/ColorTests.cs
+++ b/tests/dotless.Core.Test/Unit/Parser/ColorTests.cs
@@ -1,0 +1,17 @@
+﻿namespace dotless.Core.Test.Specs.Functions
+{
+    using NUnit.Framework;
+    using Color = Core.Parser.Tree.Color;
+
+    public class ColorTests
+    {
+        [Test]
+        public void TestColor()
+        {
+            var color = new Color("#ff0000");
+            Assert.AreEqual(255, color.R);
+            Assert.AreEqual(0, color.G);
+            Assert.AreEqual(0, color.B);
+        }
+    }
+}

--- a/tests/dotless.Core.Test/Unit/Parser/ColorTests.cs
+++ b/tests/dotless.Core.Test/Unit/Parser/ColorTests.cs
@@ -1,4 +1,4 @@
-﻿namespace dotless.Core.Test.Specs.Functions
+﻿namespace dotless.Core.Test.Unit.Parser
 {
     using NUnit.Framework;
     using Color = Core.Parser.Tree.Color;
@@ -6,7 +6,7 @@
     public class ColorTests
     {
         [Test]
-        public void TestColor()
+        public void Color_ConstructedFromHexString_RgbValuesDoNotThrow()
         {
             var color = new Color("#ff0000");
             Assert.AreEqual(255, color.R);


### PR DESCRIPTION
Usage of new Color("#ff0000") would throw an object null reference exception.  
Quoted was not being cloned properly, resulting in issue #507.