### PR TITLE
Added support for being able to supply an instance of a logger

### DIFF
--- a/src/dotless.Core/ContainerFactory.cs
+++ b/src/dotless.Core/ContainerFactory.cs
@@ -44,6 +44,9 @@
         {
             if (configuration.Logger != null)
                 services.AddSingleton(typeof(ILogger), configuration.Logger);
+
+            if (configuration.LoggerInstance != null)
+                services.AddSingleton(typeof(ILogger), configuration.LoggerInstance);
         }
 
         protected virtual void RegisterLocalServices(IServiceCollection services)

--- a/src/dotless.Core/configuration/DotlessConfiguration.cs
+++ b/src/dotless.Core/configuration/DotlessConfiguration.cs
@@ -185,6 +185,11 @@
         public Type Logger { get; set; }
 
         /// <summary>
+        /// An instance of the logger that you wish to use
+        /// </summary>
+        public ILogger LoggerInstance { get; set; }
+
+        /// <summary>
         ///  The Log level
         /// </summary>
         public LogLevel LogLevel { get; set; }


### PR DESCRIPTION
Currently there is no way to supply and instance of a logger, you can only pass through the type that you want instantiated and then the DI framework will create a singleton of it. It would be nice if you could pass through an instance so that you can trap errors thrown for a specific instance. This pull request adds that feature.