### PR TITLE
Add Children overview page with LESS styling

### DIFF
--- a/src/dotless.SampleWeb/Content/Children.less
+++ b/src/dotless.SampleWeb/Content/Children.less
@@ -1,0 +1,61 @@
+@child-bg: #f5f7fa;
+@child-border: #d0d7e2;
+@child-name-color: #2c3e50;
+@child-age-color: #7f8c8d;
+@child-description-color: #555;
+@stack-gap: 12px;
+
+.children-overview {
+    padding: 24px;
+
+    h2 {
+        font-size: 1.6em;
+        margin-bottom: 8px;
+        color: @child-name-color;
+    }
+
+    .parent-label {
+        margin-bottom: 20px;
+        color: @child-age-color;
+    }
+}
+
+.stack-layout {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
+    flex-direction: column;
+
+    .child-view {
+        background: @child-bg;
+        border: 1px solid @child-border;
+        border-radius: 4px;
+        padding: 14px 18px;
+        margin-bottom: @stack-gap;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+
+        .child-name {
+            font-size: 1.1em;
+            font-weight: bold;
+            color: @child-name-color;
+            margin-bottom: 4px;
+        }
+
+        .child-age {
+            font-size: 0.85em;
+            color: @child-age-color;
+            margin-bottom: 6px;
+        }
+
+        .child-description {
+            font-size: 0.9em;
+            color: @child-description-color;
+        }
+    }
+}

--- a/src/dotless.SampleWeb/Controllers/ChildrenController.cs
+++ b/src/dotless.SampleWeb/Controllers/ChildrenController.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Web.Mvc;
+using dotless.SampleWeb.Models;
+
+namespace dotless.SampleWeb.Controllers
+{
+    [HandleError]
+    public class ChildrenController : Controller
+    {
+        public ActionResult Index()
+        {
+            var children = new List<ChildViewModel>
+            {
+                new ChildViewModel { Name = "Alice", Age = 7, Description = "Loves drawing and painting" },
+                new ChildViewModel { Name = "Bob", Age = 10, Description = "Enjoys football and reading" },
+                new ChildViewModel { Name = "Clara", Age = 5, Description = "Favourite hobby is playing piano" },
+                new ChildViewModel { Name = "David", Age = 12, Description = "Keen on science and robotics" },
+                new ChildViewModel { Name = "Eva", Age = 8, Description = "Passionate about swimming" }
+            };
+
+            var model = new ChildrenOverviewViewModel("Parent", children);
+
+            return View(model);
+        }
+    }
+}

--- a/src/dotless.SampleWeb/Models/ChildViewModel.cs
+++ b/src/dotless.SampleWeb/Models/ChildViewModel.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace dotless.SampleWeb.Models
+{
+    public class ChildViewModel
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+        public string Description { get; set; }
+    }
+
+    public class ChildrenOverviewViewModel
+    {
+        public string ParentName { get; set; }
+        private readonly List<ChildViewModel> _children;
+
+        public ChildrenOverviewViewModel(string parentName, IEnumerable<ChildViewModel> children)
+        {
+            ParentName = parentName;
+            _children = children.Take(4).ToList();
+        }
+
+        public IReadOnlyList<ChildViewModel> Children
+        {
+            get { return _children; }
+        }
+    }
+}

--- a/src/dotless.SampleWeb/Views/Children/Index.cshtml
+++ b/src/dotless.SampleWeb/Views/Children/Index.cshtml
@@ -1,0 +1,21 @@
+@model dotless.SampleWeb.Models.ChildrenOverviewViewModel
+@{
+    Layout = "~/Views/Shared/_master.cshtml";
+    ViewBag.Title = "Children Overview";
+}
+
+<div class="children-overview">
+    <h2>Children Overview</h2>
+    <p class="parent-label">Parent: <strong>@Model.ParentName</strong></p>
+
+    <div class="stack-layout">
+        @foreach (var child in Model.Children)
+        {
+            <div class="child-view">
+                <div class="child-name">@child.Name</div>
+                <div class="child-age">Age: @child.Age</div>
+                <div class="child-description">@child.Description</div>
+            </div>
+        }
+    </div>
+</div>

--- a/src/dotless.SampleWeb/Views/Shared/_master.cshtml
+++ b/src/dotless.SampleWeb/Views/Shared/_master.cshtml
@@ -6,6 +6,7 @@
 
 	@Styles.Render("~/Content/Site.less")
 	@Styles.Render("~/Content/subfolder/test.less")
+	@Styles.Render("~/Content/Children.less")
 </head>
 <body>
 	<div id="header" class="container">
@@ -16,7 +17,8 @@
 			LOGIN AND DISPLAY
 		</div>
 		<div id="menucontainer">
-			MENU CONTAINER
+			@Html.ActionLink("Home", "Index", "Home") |
+			@Html.ActionLink("Children", "Index", "Children")
 		</div>
 	</div>
 

--- a/src/dotless.SampleWeb/dotless.SampleWeb.csproj
+++ b/src/dotless.SampleWeb/dotless.SampleWeb.csproj
@@ -153,7 +153,9 @@
     <Compile Include="App_Start\BundleConfig.cs" />
     <Compile Include="App_Start\FilterConfig.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
+    <Compile Include="Controllers\ChildrenController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Models\ChildViewModel.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
@@ -192,6 +194,7 @@
     <Content Include="fonts\glyphicons-halflings-regular.svg" />
     <Content Include="Global.asax" />
     <Content Include="Content\blueprint\screen.less" />
+    <Content Include="Content\Children.less" />
     <Content Include="Content\Site.less" />
     <Content Include="Content\subfolder\test.less" />
     <Content Include="Content\Web.config" />
@@ -204,6 +207,7 @@
     <Content Include="Scripts\jquery.validate.unobtrusive.js" />
     <Content Include="Scripts\jquery.validate.unobtrusive.min.js" />
     <Content Include="Scripts\_references.js" />
+    <None Include="Views\Children\Index.cshtml" />
     <None Include="Views\Home\Index.cshtml" />
     <Content Include="Web.config" />
     <Content Include="Web.Debug.config">


### PR DESCRIPTION
## Summary
This PR adds a new Children overview feature to the sample web application, including a dedicated controller, view models, Razor view, and LESS stylesheet.

## Key Changes
- **New Controller**: `ChildrenController` with an `Index` action that displays a list of children with sample data
- **New View Models**: 
  - `ChildViewModel` - represents individual child data (Name, Age, Description)
  - `ChildrenOverviewViewModel` - aggregates parent name and up to 4 children
- **New View**: `Views/Children/Index.cshtml` - displays children in a card-based layout with parent information
- **New Stylesheet**: `Content/Children.less` - provides styling for the children overview page with:
  - Color variables for consistent theming
  - Flexbox-based stack layout for child cards
  - Responsive card styling with borders and padding
- **Updated Navigation**: Modified `_master.cshtml` to include navigation links to Home and Children pages
- **Project File Updates**: Added new files to the `.csproj` project configuration

## Implementation Details
- The `ChildrenOverviewViewModel` limits the displayed children to a maximum of 4 using LINQ's `Take()` method
- The LESS stylesheet uses variables for colors and spacing to maintain consistency
- Child cards are displayed in a vertical flexbox layout with consistent spacing and styling
- The view iterates through the children collection to render individual child cards with name, age, and description

https://claude.ai/code/session_01KG3oZS7LHLdrNmQtah21Hx